### PR TITLE
Make mongo wait for operations to complete before closing

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -311,7 +311,7 @@ var AppComponent = React.createClass({
       formNotification: {
         type: 'success',
         message: [
-          'You data was successfully uploaded to Tidepool!',
+          'Your data was successfully uploaded to Tidepool!',
           'It is now safe to close this window.'
         ].join(' ')
       }

--- a/lib/children/load.js
+++ b/lib/children/load.js
@@ -82,6 +82,7 @@ function go(config) {
 
       var eventCount = 0;
       var resultsArray = [];
+      var persistCount = 0;
       rx.Observable
         .fromArray(files)
         .flatMap(function (locSpec) {
@@ -139,8 +140,10 @@ function go(config) {
                 fail('Problem with DB, Oh Noes!', err);
               }
             }
-            log.info('Successfully persisted[%s] events to db.', eventCount);
-            process.exit(0);
+            log.info('Persisted[%s] events to db.', eventCount);
+            mongoClient.close(function(err, results){
+              process.exit(0);
+            });
           });
         });
     }
@@ -170,6 +173,11 @@ function fetch(groupId, filename, config, cb) {
     var startTime = new Date().valueOf();
     var bytesPulled = 0;
     antacid.fetch(config, function (err, dataStream) {
+      if (err != null) {
+        fail('Couldn\'t fetch!?', err);
+        return;
+      }
+
       dataStream.on('data', function (chunk) {
         if (bytesPulled == 0) {
           log.info('First byte pulled in [%s] millis.', new Date().valueOf() - startTime);

--- a/lib/dataBroker.js
+++ b/lib/dataBroker.js
@@ -18,20 +18,14 @@
 module.exports = function(mongoClient){
   return {
     storeData: function(data, cb) {
-      mongoClient.withCollection('deviceData', function(err, collection) {
-        if (err != null) {
-          return cb(err);
-        }
+      mongoClient.withCollection('deviceData', cb, function(collection, cb){
         collection.insert(data, {keepGoing: true}, cb);
       });
     },
     deleteData: function(groupId, cb) {
-      mongoClient.withCollection('deviceData', function(err, collection) {
-        if (err != null) {
-          return cb(err);
-        }
+      mongoClient.withCollection('deviceData', cb, function(collection, cb){
         collection.remove({ groupId: groupId }, cb);
-      })
+      });
     }
   }
 };

--- a/lib/mongo/mongoClient.js
+++ b/lib/mongo/mongoClient.js
@@ -15,39 +15,84 @@
  * == BSD2 LICENSE ==
  */
 
+var _ = require('lodash');
 var mongodb = require('mongodb');
 var pre = require('amoeba').pre;
 
 var log = require('../log.js')('mongoClient.js');
 
 module.exports = function(config){
+  config = _.clone(config);
   pre.hasProperty(config, 'connectionString');
+  pre.defaultProperty(config, 'closeDelay', 60 * 1000);
+  pre.defaultProperty(config, 'closePollDelay', 5000);
+
 
   var mongoClient = null;
+  var started = false;
+  var requestCount = 0;
+
+  function closeWhenRequestsDone(clientRef, timeElapsed, cb) {
+    if (requestCount > 0) {
+      if (timeElapsed >= config.closeDelay) {
+        log.warn('Forcibly closing mongo because operations didn\'t clear out within [%s] millis', config.closeDelay);
+        clientRef.close(cb);
+      } else {
+        setTimeout(
+          closeWhenRequestsDone.bind(null, clientRef, timeElapsed + config.closePollDelay, cb),
+          config.closePollDelay
+        );
+      }
+    } else {
+      log.info('Closing mongo client');
+      clientRef.close(cb);
+    }
+  }
 
   return {
-    withCollection: function(collection, errorCb, happyCb) {
-      if (mongoClient == null) {
-        return errorCb(new Error('Must start the mongoClient before using it.'));
+    /**
+     * Provides the requested collection object from Mongo to the collCb.
+     *
+     * The function signature on this method is a little funky because it attempts to do
+     * request counting in order to handle the close() method gracefully.  The collCb will be
+     * passed a callback that it *must* use.  This callback wraps the clientCb passed in here,
+     * but decrements the request counter before calling it.
+     *
+     * Not using the callback passed to collCb will result in incorrect counts and elongated
+     * `close()` times.
+     *
+     * @param collection String name of the mongo collection to get
+     * @param clientCb Callback from the user, if an error occurs, this will short-circuit to this callback directly.
+     * @param collCb callback that is passed the collection as the first argument and a callback as the second argument,
+     *   the callback passed into collCb *must* be called from collCb
+     * @returns {*}
+     */
+    withCollection: function(collection, clientCb, collCb) {
+      if (! started) {
+        return clientCb(new Error('Must start the mongoClient before using it.'));
       }
 
-      if (happyCb == null) {
-        happyCb = function(coll) {
-          return errorCb(null, coll);
-        };
+      if (mongoClient == null) {
+        return clientCb(new Error('Client closing, cannot be used.'));
       }
+
       mongoClient.collection(collection, function(err, collection) {
         if (err != null) {
-          errorCb(err);
+          clientCb(err);
         }
-        happyCb(collection);
+
+        var requestComplete = false;
+        ++requestCount;
+        collCb(collection, function(error) {
+          if (! requestComplete) {
+            requestComplete = true;
+            --requestCount;
+          }
+          clientCb.apply(null, Array.prototype.slice.call(arguments, 0));
+        });
       });
     },
     start: function(cb){
-      if (mongoClient != null) {
-        return;
-      }
-
       if (cb == null) {
         cb = function(err) {
           if (err != null) {
@@ -58,21 +103,33 @@ module.exports = function(config){
         }
       }
 
+      if (started) {
+        return cb(new Error('Already started'));
+      }
+      requestCount = 0;
+
       mongodb.MongoClient.connect(config.connectionString, function(err, db){
         if (db != null) {
           if (mongoClient != null) {
             db.close();
             return;
           }
+          started = true;
           mongoClient = db;
         }
 
         cb(err);
       });
     },
-    close: function() {
-      if (mongoClient != null) {
-        mongoClient.close();
+    close: function(cb) {
+      if (started) {
+        closeWhenRequestsDone(mongoClient, 0, function(err, results){
+          started = false;
+          if (cb != null) {
+            cb(err, results);
+          }
+        });
+
         mongoClient = null;
       }
     }

--- a/lib/storage/local.js
+++ b/lib/storage/local.js
@@ -62,7 +62,7 @@ module.exports = function (config) {
       return fs.createReadStream(location);
     },
     save: function(userId, filename, data, cb) {
-      var baseDir = path.resolve(path.join(config.storageDir, moment.utc().format(), String(userId)));
+      var baseDir = path.resolve(path.join(config.storageDir, String(userId), moment.utc().format()));
 
       files.mkdirsSync(baseDir);
       fileWriter(data, path.join(baseDir, filename))(cb);

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -19,41 +19,41 @@ var ObjectID = require('mongodb').ObjectID;
 var pre = require('amoeba').pre;
 
 module.exports = function(mongoClient) {
-  function syncTasks(errorCb, happyCb) {
-    mongoClient.withCollection('syncTasks', errorCb, happyCb);
+  function syncTasks(clientCb, collCb) {
+    mongoClient.withCollection('syncTasks', clientCb, collCb);
   }
 
   return {
     create: function(cb) {
-      syncTasks(cb, function(collection){
+      syncTasks(cb, function(collection, callback){
         // Mongo doesn't give you the document you created back on insert, so we either have
         // to look it up again, or generate the ID here.  We choose the latter.
         var id = new ObjectID().toString();
         collection.insert({_id: id, status: 'created'}, function(err, result){
-          cb(err, id);
+          callback(err, id);
         })
       });
     },
     get: function(id, cb) {
-      syncTasks(cb, function(collection){
-        collection.findOne({_id: id}, cb);
+      syncTasks(cb, function(collection, callback){
+        collection.findOne({_id: id}, callback);
       });
     },
     save: function(task, cb) {
-      syncTasks(cb, function(collection){
-        collection.save(task, cb);
+      syncTasks(cb, function(collection, callback){
+        collection.save(task, callback);
       });
     },
     update: function(taskId, updates, cb) {
-      syncTasks(cb, function(collection){
+      syncTasks(cb, function(collection, callback){
         collection.update({_id: taskId}, updates, function(err, results){
-          cb(err, results);
+          callback(err, results);
         });
       });
     },
     deleteAll: function(cb) {
-      syncTasks(cb, function(collection){
-        collection.remove(cb);
+      syncTasks(cb, function(collection, callback){
+        collection.remove(callback);
       });
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "in-d-gestion": "0.1.4",
     "lodash": "2.4.1",
     "moment": "2.4.0",
-    "mongodb": "1.3.23",
+    "mongodb": "1.4.0",
     "reactify": "0.8.1",
     "request": "2.33.0",
     "run-sequence": "0.3.6",


### PR DESCRIPTION
There was a bug with load.js ending before all things had successfully persisted to mongo.  We must make sure that all mongo operations have completed before exiting from load.js.

MongoClient.close() just interrupts current operations, so we cannot rely on that, but instead have to keep track of if there is an operation in flight before closing.  This change introduces a request counting mechanism to mongoClient and adjusts everything to use it.

@kentquirk can I get your eyes on this?
