### PR TITLE
Add missing generation of _groupId for square bolus

### DIFF
--- a/lib/schema/bolus.js
+++ b/lib/schema/bolus.js
@@ -72,6 +72,7 @@ module.exports = function(streamDAO){
             if (datum.previous == null) {
               return cb(null, datum);
             } else {
+              datum.previous._groupId = datum._groupId;
               var previous = schema.attachIds(_.clone(datum.previous), idFields);
 
               streamDAO.getDatum(previous._id, function(err, prev){


### PR DESCRIPTION
@cheddar -- this fixes a problem I had uploading square boluses. You agree?
