### PR TITLE
Fix issue with dexcom-only uploads breaking

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "lodash": "2.4.1",
     "purl": "2.3.1",
     "react": "0.9.0",
-    "sundial": "https://github.com/tidepool-org/sundial.git#v0.1.4"
+    "sundial": "0.1.5"
   },
   "version": "0.0.51"
 }

--- a/lib/uploadFlow.js
+++ b/lib/uploadFlow.js
@@ -114,10 +114,9 @@ module.exports = function (config, tasks) {
     }
 
     if (formParams.dexcom != null) {
-      retVal.dexcom = _.assign(_.omit(formParams.dexcom, 'dexcomTimezone'), {timezone: formParams.dexcomTimezone});
+      retVal.dexcom = _.assign({}, formParams.dexcom, {timezone: formParams.dexcomTimezone});
     }
 
-    retVal.dexcom = formParams.dexcom;
     return retVal;
   }
 


### PR DESCRIPTION
The dexcom config object was getting clobbered, probably because of a line of code that survived a merge conflict that shouldn't've.  Fixed now.

Also, introduce new version of sundial
