### PR TITLE
don't assume a suppressed with a rate is always available in a temp basal

### DIFF
--- a/lib/schema/basal.js
+++ b/lib/schema/basal.js
@@ -148,7 +148,9 @@ module.exports = function(streamDAO){
           },
           transform: function(datum, cb){
             if (datum.rate == null && datum.percent != null) {
-              datum.rate = datum.suppressed.rate * datum.percent;
+              if (datum.suppressed != null && datum.suppressed.rate != null) {
+                datum.rate = datum.suppressed.rate * datum.percent;
+              }
             }
 
             if (datum.rate == null && datum.percent == null) {


### PR DESCRIPTION
When the CareLink settings history is incomplete, we'll get temps that don't even have a `suppressed`.

@jh-bate plz review.