### PR TITLE
make wizards pass validation w/o a recommended field

### DIFF
--- a/lib/schema/wizard.js
+++ b/lib/schema/wizard.js
@@ -24,7 +24,7 @@ var idFields = ['type', 'deviceId', 'time'];
 schema.registerIdFields('wizard', idFields);
 
 var recommendedSchema = schema.and(
-    schema.ifExists(schema.isObject),
+    schema.isObject,
     schema.ensureSchemaFn('recommended', {
         carb: schema.ifExists(schema.isNumber),
         correction: schema.ifExists(schema.isNumber),
@@ -36,7 +36,7 @@ var recommendedSchema = schema.and(
 
 module.exports = schema.makeHandler('wizard', {
   schema: {
-    recommended: recommendedSchema,
+    recommended: schema.ifExists(recommendedSchema),
     bgInput: schema.ifExists(schema.isNumber),
     carbInput: schema.ifExists(schema.isNumber),
     insulinOnBoard: schema.ifExists(schema.isNumber),

--- a/test/schema/wizardTest.js
+++ b/test/schema/wizardTest.js
@@ -229,7 +229,7 @@ describe('schema/wizard.js', function(){
   });
 
   describe('recommended', function(){
-    helper.rejectIfAbsent(goodObject, 'recommended');
+    helper.okIfAbsent(goodObject, 'recommended');
     helper.expectObjectField(goodObject, 'recommended');
 
     it('carb is a numeric field', function(done){


### PR DESCRIPTION
@kentquirk 

Small jellyfish bugfix: `recommended` should be a truly optional field on wizard records; I tested this locally and it seems to work. (Basically everything is optional on wizard records because data quality varies widely on this from device to device.)