### PR TITLE
preserve all status reasons

### DIFF
--- a/lib/schema/deviceMeta.js
+++ b/lib/schema/deviceMeta.js
@@ -32,6 +32,14 @@ schema.registerIdFields('deviceMeta', idFields);
 
 var statusReasons = ['manual', 'automatic'];
 
+var reasonSchema = schema.and(
+  schema.isObject,
+  schema.ensureSchemaFn('reason', {
+    suspended: schema.ifExists(schema.in(statusReasons)),
+    resumed: schema.ifExists(schema.in(statusReasons)),
+  })
+);
+
 var changeSchema = schema.and(
   schema.isObject,
   schema.ensureSchemaFn('change', {
@@ -71,14 +79,15 @@ module.exports = function(streamDAO){
         {
           schema: {
             status: schema.in('suspended', 'resumed'),
-            reason: schema.in(statusReasons),
+            reason: reasonSchema,
             duration: schema.ifExists(schema.isNumber),
             previous: schema.ifExists(schema.isObject)
           },
           transform: function(datum, cb) {
-            if (!_.includes(statusReasons, datum.reason)) {
+            var reason = datum.reason.suspended ? datum.reason.suspended : datum.reason.resumed;
+            if (!_.includes(statusReasons, reason)) {
               return cb(
-                { statusCode: 400, message: util.format('Unknown reason[%s] for status[%s]', datum.reason, datum.status) }
+                { statusCode: 400, message: util.format('Unknown reason[%s] for status[%s]', reason, datum.status) }
               );
             }
 
@@ -96,6 +105,7 @@ module.exports = function(streamDAO){
                 } else  {
                   prev = schema.removeAnnotation(prev, INCOMPLETE_TUPLE);
                   prev.duration = moment.utc(datum.time).valueOf() - moment.utc(prev.time).valueOf();
+                  prev.reason = _.assign({}, prev.reason, datum.reason);
 
                   if (datum.status === 'resumed') {
                     return cb(null, prev);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfish",
-  "version": "0.8.0",
+  "version": "0.8.0-demo",
   "description": "Jellyfish are known for their user friendliness with uploads",
   "main": "app.js",
   "scripts": {

--- a/test/api/deviceMeta/input.json
+++ b/test/api/deviceMeta/input.json
@@ -15,7 +15,9 @@
             "deviceTime": "2014-07-27T17:07:10",
             "deviceId": "test",
             "uploadId": "test",
-            "reason": "manual",
+            "reason": {
+                "suspended": "manual"
+            },
             "time": "2014-07-28T00:07:10.000Z",
             "timezoneOffset": -420
         }
@@ -35,7 +37,9 @@
             "deviceTime": "2014-07-27T17:07:10",
             "deviceId": "test",
             "uploadId": "test",
-            "reason": "manual",
+            "reason": {
+                "suspended": "manual"
+            },
             "time": "2014-07-28T00:07:10.000Z",
             "timezoneOffset": -420
         }
@@ -47,7 +51,9 @@
         "deviceTime": "2014-07-27T17:07:10",
         "deviceId": "test",
         "uploadId": "test",
-        "reason": "manual",
+        "reason": {
+            "suspended": "manual"
+        },
         "time": "2014-07-28T00:07:10.000Z",
         "timezoneOffset": -420
     },
@@ -58,7 +64,9 @@
         "deviceTime": "2014-07-27T17:07:24",
         "deviceId": "Paradigm Revel - 723",
         "uploadId": "test",
-        "reason": "manual",
+        "reason": {
+            "resumed": "manual"
+        },
         "time": "2014-07-28T00:07:24.000Z",
         "timezoneOffset": -420,
         "previous": {
@@ -68,7 +76,9 @@
             "deviceTime": "2014-07-27T17:07:10",
             "deviceId": "test",
             "uploadId": "test",
-            "reason": "manual",
+            "reason": {
+                "suspended": "manual"
+            },
             "time": "2014-07-28T00:07:10.000Z",
             "timezoneOffset": -420
         }

--- a/test/api/deviceMeta/output.json
+++ b/test/api/deviceMeta/output.json
@@ -35,7 +35,9 @@
         "deviceTime": "2014-07-27T17:07:10",
         "deviceId": "test",
         "uploadId": "test",
-        "reason": "manual",
+        "reason": {
+            "suspended": "manual"
+        },
         "time": "2014-07-28T00:07:10.000Z",
         "timezoneOffset": -420,
         "_groupId": "1234",
@@ -55,7 +57,10 @@
         "deviceTime": "2014-07-27T17:07:10",
         "deviceId": "test",
         "uploadId": "test",
-        "reason": "manual",
+        "reason": {
+            "suspended": "manual",
+            "resumed": "manual"
+        },
         "time": "2014-07-28T00:07:10.000Z",
         "timezoneOffset": -420,
         "_groupId": "1234",

--- a/test/schema/deviceMetaTest.js
+++ b/test/schema/deviceMetaTest.js
@@ -82,7 +82,7 @@ describe('schema/deviceMeta.js', function(){
       type: 'deviceMeta',
       subType: 'status',
       status: 'suspended',
-      reason: 'automatic',
+      reason: {suspended: 'automatic'},
       time: '2014-01-01T00:00:00.000Z',
       timezoneOffset: 120,
       deviceId: 'test',
@@ -94,7 +94,7 @@ describe('schema/deviceMeta.js', function(){
       type: 'deviceMeta',
       subType: 'status',
       status: 'suspended',
-      reason: 'manual',
+      reason: {suspended: 'manual'},
       time: '2014-01-01T00:00:00.000Z',
       timezoneOffset: 120,
       deviceId: 'test',
@@ -106,7 +106,7 @@ describe('schema/deviceMeta.js', function(){
       type: 'deviceMeta',
       subType: 'status',
       status: 'resumed',
-      reason: 'manual',
+      reason: {resumed: 'manual'},
       time: '2014-01-01T01:00:00.000Z',
       timezoneOffset: 120,
       deviceId: 'test',
@@ -139,8 +139,37 @@ describe('schema/deviceMeta.js', function(){
 
     describe('reason', function(){
       helper.rejectIfAbsent(goodObject, 'reason');
-      helper.expectStringField(goodObject, 'reason');
-      helper.expectFieldIn(goodObject, 'reason', ['manual', 'automatic']);
+      helper.expectObjectField(goodObject, 'reason');
+
+      it('suspended is a string field', function(done) {
+        var obj = _.cloneDeep(goodObject);
+        obj.reason.suspended = 1;
+        helper.expectRejection(obj, 'reason', done);
+      });
+
+      it('suspended is not a `foo` value', function(done) {
+        var obj = _.cloneDeep(goodObject);
+        obj.reason.suspended = 'foo';
+        helper.expectRejection(obj, 'reason', done);
+      });
+
+      it('resumed is a string field', function(done) {
+        var obj = _.cloneDeep(goodObject);
+        obj.reason.resumed = 1;
+        helper.expectRejection(obj, 'reason', done);
+      });
+
+      it('resumed is not a `foo` value', function(done) {
+        var obj = _.cloneDeep(goodObject);
+        obj.reason.resumed = 'foo';
+        helper.expectRejection(obj, 'reason', done);
+      });
+
+      it('cannot be empty', function(done) {
+        var obj = _.cloneDeep(goodObject);
+        obj.reason = {};
+        helper.expectRejection(obj, 'reason', done);
+      });
     });
 
     describe('previous', function(){
@@ -210,7 +239,7 @@ describe('schema/deviceMeta.js', function(){
 
         var localGoodObject = _.assign({}, goodObject, { status: 'resumed' });
         helper.run(_.assign({}, localGoodObject, {previous: previousMatches}), done, function(objs) {
-          helper.expectSubsetEqual(objs, _.assign({}, previousMatches, {duration: 60 * 60 * 1000}));
+          helper.expectSubsetEqual(objs, _.assign({}, previousMatches, {duration: 60 * 60 * 1000}, {reason: _.assign({}, localGoodObject.reason, previousMatches.reason)}));
         });
       });
 
@@ -226,7 +255,7 @@ describe('schema/deviceMeta.js', function(){
         var localGoodObject = _.assign({}, goodObject, { status: 'suspended' });
         helper.run(_.assign({}, localGoodObject, {previous: previousMatches}), done, function(objs) {
           expect(objs).length(2);
-          helper.expectSubsetEqual(objs[0], _.assign({}, previousMatches, {duration: 60 * 60 * 1000}));
+          helper.expectSubsetEqual(objs[0], _.assign({}, previousMatches, {duration: 60 * 60 * 1000}, {reason: _.assign({}, localGoodObject.reason, previousMatches.reason)}));
           helper.expectSubsetEqual(objs[1], _.assign({}, localGoodObject, {annotations: [{ code: "status/incomplete-tuple" }]}));
         });
       });


### PR DESCRIPTION
An additional jellyfish tweak to update to our most current data model after realizing Insulet and CareLink were at different levels of data model revision (and CareLink was broken on v0.8.0 jellyfish). Now everybody will be 100% up-to-date.

Insulet demo uploader will depend on this, so I'll be tagging on this branch and deploying to devel.

https://github.com/tidepool-org/chrome-uploader/pull/72 is dependent on this.