### PR TITLE
remove unused sundial dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "mongodb": "1.4.29",
     "request": "2.51.0",
     "rx": "2.3.24",
-    "sundial": "0.1.6",
     "tidepool-seagull-client": "0.0.2",
     "user-api-client": "0.1.4",
     "tidepool-gatekeeper": "0.1.5"


### PR DESCRIPTION
Turns out sundial isn't even used in jellyfish anymore (presumably due to the new lack of UI), so it's not a blocker for doing an npm scrub here.