### PR TITLE
preserve suspend and resume payloads

### DIFF
--- a/lib/schema/deviceMeta.js
+++ b/lib/schema/deviceMeta.js
@@ -108,7 +108,7 @@ module.exports = function(streamDAO){
                   prev.reason = _.assign({}, prev.reason, datum.reason);
 
                   if (datum.status === 'resumed') {
-                    var prevPayload = prev.payload || {};
+                    var prevPayload = _.clone(prev.payload) || {};
                     var thisPayload = _.clone(datum.payload) || {};
                     if (!_.isEmpty(prevPayload)) {
                       prev.payload = _.assign({}, {suspended: prevPayload});

--- a/lib/schema/deviceMeta.js
+++ b/lib/schema/deviceMeta.js
@@ -108,6 +108,14 @@ module.exports = function(streamDAO){
                   prev.reason = _.assign({}, prev.reason, datum.reason);
 
                   if (datum.status === 'resumed') {
+                    var prevPayload = prev.payload || {};
+                    var thisPayload = _.clone(datum.payload) || {};
+                    if (!_.isEmpty(prevPayload)) {
+                      prev.payload = _.assign({}, {suspended: prevPayload});
+                    }
+                    if (!_.isEmpty(thisPayload)) {
+                      prev.payload = _.assign({}, prev.payload, {resumed: thisPayload});
+                    }
                     return cb(null, prev);
                   } else {
                     return cb(null, [prev, schema.annotateEvent(datum, INCOMPLETE_TUPLE)]);


### PR DESCRIPTION
Been meaning to fix this and then needed to in order to preserve all sequencing numbers for https://github.com/tidepool-org/chrome-uploader/pull/84.

Since this is just manipulation of the optional and unvalidated payload, it causes no dependency issues. Newer uploaders will not break on jellyfishes without this PR. Older uploaders will not break on this version.