### PR TITLE
pass a datum to updateDatum if _forceUpdate flag is present

### DIFF
--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -146,6 +146,8 @@ module.exports = function(mongoClient){
       });
     },
     insertDatum: function(datum, cb) {
+      var self = this;
+
       pre.hasProperty(datum, 'id');
       pre.hasProperty(datum, '_groupId');
 
@@ -160,6 +162,10 @@ module.exports = function(mongoClient){
         coll.insert(datum, function(err){
           if (err != null) {
             if (err.code === 11000) {
+              if (datum._forceUpdate === true) {
+                delete datum._forceUpdate;
+                return self.updateDatum(datum, cb);
+              }
               return cb({ statusCode: 400, errorCode: 'duplicate', message: 'received a duplicate event'});
             }
             return cb(err);

--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -57,6 +57,7 @@ module.exports = function(mongoClient){
         });
 
         function updateItem() {
+          clone.createdTime = previous.createdTime;
           clone._version = previous._version + 1;
           clone._active = true;
 
@@ -159,11 +160,16 @@ module.exports = function(mongoClient){
       datum = ensureId(datum);
 
       mongoClient.withCollection('deviceData', cb, function(coll, cb){
+        var force = false;
+        // shift the _forceUpdate flag into local state so we never store it
+        if (datum._forceUpdate === true) {
+          force = true;
+          delete datum._forceUpdate;
+        }
         coll.insert(datum, function(err){
           if (err != null) {
             if (err.code === 11000) {
-              if (datum._forceUpdate === true) {
-                delete datum._forceUpdate;
+              if (force === true) {
                 return self.updateDatum(datum, cb);
               }
               return cb({ statusCode: 400, errorCode: 'duplicate', message: 'received a duplicate event'});

--- a/test/streamDAOTest.js
+++ b/test/streamDAOTest.js
@@ -74,6 +74,60 @@ describe('streamDAO', function(){
     });
   });
 
+  describe('insert with _forceUpdate', function(){
+    var createdTime = '';
+
+    beforeEach(function(done){
+      streamDAO.insertDatum({id: 'abcd', v: 1, f: 'a', _groupId: 'g'}, function(err){
+        if (err != null) {
+          return done(err);
+        }
+
+        streamDAO.getDatum('abcd', 'g', function(err, datum){
+          createdTime = datum.createdTime;
+          done(err);
+        });
+      });
+    });
+
+    it('should update a value with the `_forceUpdate` flag set to true', function(done){
+      var now = Date.now();
+
+      streamDAO.insertDatum({id: 'abcd', v: 2, f: 'a', _groupId: 'g', _forceUpdate: true}, function(err){
+        if (err != null) {
+          return done(err);
+        }
+
+        streamDAO.getDatum('abcd', 'g', function(err, datum){
+          expect(datum).to.exist;
+          expect(_.omit(datum, ['_id', 'modifiedTime'])).to.deep.equal({
+            id: 'abcd',
+            v: 2,
+            f: 'a',
+            _groupId: 'g',
+            _version: 1,
+            _active: true,
+            createdTime: createdTime
+          });
+          expect(Date.parse(datum.modifiedTime)).that.is.within(now, Date.now());
+
+          var overwrittenId = datum._id + '_0';
+          mongoClient.withCollection('deviceData', done, function(coll, done){
+            coll.find({_id: overwrittenId}).toArray(function(err, elements){
+              expect(elements).to.have.length(1);
+              expect(elements[0]._archivedTime).that.is.within(now, Date.now());
+              expect(_.omit(elements[0], '_archivedTime')).to.deep.equals(
+                { _id: overwrittenId, id: 'abcd', f: 'a', _groupId: 'g', v: 1, createdTime: createdTime, _version: 0, _active: false }
+              );
+
+              done(err);
+            });
+          });
+        });
+      });
+    });
+  });
+
   describe('update', function(){
     var createdTime = '';
 


### PR DESCRIPTION
This allows us to bypass jellyfish's rejection of "duplicate" events (namely, in the case where we've added a `_forceUpdate` flag on the data point).

Now, the data model docs say this about versioning: "At some future date, we will have the ability to modify events. At that time, there will be a special endpoint that allows for updating an event and in this case, it is expected that an id will be provided."

So I don't think this is the kind of solution we originally had in mind. @cheddar this is what I wanted to pick your brain on today.

Do we want this as a short-term solution so that we can fix the issues around DST with Dexcom data?

Uploader PR that this is a prerequisite for: https://github.com/tidepool-org/chrome-uploader/pull/92