### PR TITLE
Enforce schema version in getDatumBefore using a direct find (not through generated id)

### DIFF
--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -137,6 +137,7 @@ module.exports = function(mongoClient){
             time: {$lt: datum.time},
             _groupId: datum._groupId,
             _active: true,
+            _schemaVersion: datumConfig.schemaVersion,    // NOTE: This will need to be updated per type in the future.
             type: datum.type,
             deviceId: datum.deviceId,
             source: datum.source


### PR DESCRIPTION
@jebeck @jh-bate There was a hard-coded mongo find here that did not use generateId when getting a previous datum.  With this single change, I get the expected result.  That is, same exact _schemaVersion=0 records (count and contents) before and after an upload after bootstrapUTC is deployed.)