### PR TITLE
move uploader version check before schema validation

### DIFF
--- a/lib/dataBroker.js
+++ b/lib/dataBroker.js
@@ -25,7 +25,8 @@ var amoeba = require('amoeba');
 var except = amoeba.except;
 
 var schemaBuilder = require('./schema');
-
+var uploadConfig = require('./schema/schemaEnv');
+var schema = require('./schema/schema.js');
 
 module.exports = function(streamDAO) {
   var schemas = schemaBuilder(streamDAO);
@@ -38,6 +39,28 @@ module.exports = function(streamDAO) {
         return cb(
           { statusCode: 400, message: util.format('Unknown type[%s], known types[%s]', datum.type, knownTypes) }
         );
+      }
+      /*
+       * This is a hacky place to move this logic, but we need it to run
+       * before schema validation is attempted (or else it's pointless)
+       * so ¯\_(ツ)_/¯
+       */
+      if (datum.type === 'upload') {
+        var versionStr = datum.version.toLowerCase();
+
+        // TODO: longterm this check should be against a datamodel version
+        // and also probably not a hard go/no-go check
+        if (versionStr.indexOf('tidepool-uploader') !== -1 && uploadConfig.minimumUploaderVersion !== null ) {
+          var versionNum = versionStr.split(' ')[1];
+          if (!schema.isValidVersion(versionNum, uploadConfig.minimumUploaderVersion)) {
+            return cb({
+              statusCode: 400,
+              text: 'The minimum supported version is ['+uploadConfig.minimumUploaderVersion+']. Version ['+datum.version+'] is no longer supported.',
+              code: 'outdatedVersion',
+              errorField: 'version'
+            });
+          }
+        }
       }
 
       handler(datum, function(err, toAdd) {

--- a/lib/dataBroker.js
+++ b/lib/dataBroker.js
@@ -48,18 +48,28 @@ module.exports = function(streamDAO) {
       if (datum.type === 'upload') {
         var versionStr = datum.version.toLowerCase();
 
-        // TODO: longterm this check should be against a datamodel version
-        // and also probably not a hard go/no-go check
-        if (versionStr.indexOf('tidepool-uploader') !== -1 && uploadConfig.minimumUploaderVersion !== null ) {
-          var versionNum = versionStr.split(' ')[1];
-          if (!schema.isValidVersion(versionNum, uploadConfig.minimumUploaderVersion)) {
-            return cb({
-              statusCode: 400,
-              text: 'The minimum supported version is ['+uploadConfig.minimumUploaderVersion+']. Version ['+datum.version+'] is no longer supported.',
-              code: 'outdatedVersion',
-              errorField: 'version'
-            });
+        if (uploadConfig.minimumUploaderVersion !== null) {
+          // TODO: longterm this check should be against a datamodel version
+          // and also probably not a hard go/no-go check
+          if (versionStr.indexOf('tidepool-uploader') !== -1) {
+            var versionNum = versionStr.split(' ')[1];
+            if (!schema.isValidVersion(versionNum, uploadConfig.minimumUploaderVersion)) {
+              return cb({
+                statusCode: 400,
+                text: 'The minimum supported version is ['+uploadConfig.minimumUploaderVersion+']. Version ['+datum.version+'] is no longer supported.',
+                code: 'outdatedVersion',
+                errorField: 'version'
+              });
+            }
           }
+        }
+        else {
+          return cb({
+            statusCode: 400,
+            text: 'No minimum uploader version configured!',
+            code: 'minUploaderVersionNotConfigured',
+            errorField: 'version'
+          });
         }
       }
 

--- a/lib/schema/upload.js
+++ b/lib/schema/upload.js
@@ -18,7 +18,6 @@
 'use strict';
 
 var schema = require('./schema.js');
-var uploadConfig = require('./schemaEnv.js');
 
 var idFields = ['type', 'deviceId', 'time'];
 schema.registerIdFields('upload', idFields);
@@ -41,20 +40,5 @@ module.exports = schema.makeHandler('upload', {
     deviceModel: schema.isString,
     deviceSerialNumber: schema.isString,
     version: schema.isString
-  },
-  transform: function(datum, cb) {
-
-    var versionStr = datum.version.toLowerCase();
-
-    // TODO: longterm this check should be against a datamodel version
-    // and also probably not a hard go/no-go check
-    if ( versionStr.indexOf('tidepool-uploader') !== -1 && uploadConfig.minimumUploaderVersion !== null ) {
-      var versionNum = versionStr.split(' ')[1];
-      if ( schema.isValidVersion(versionNum, uploadConfig.minimumUploaderVersion)) {
-        return cb(null,datum);
-      }
-      return cb({ statusCode: 400, text : 'The minimum supported version is ['+uploadConfig.minimumUploaderVersion+']. Version ['+datum.version+'] is no longer supported.', code: 'outdatedVersion', errorField: 'version'});
-    }
-    return cb(null,datum);
   }
 });

--- a/test/api/ingestionApiTest.js
+++ b/test/api/ingestionApiTest.js
@@ -73,6 +73,31 @@ describe('ingestion API', function () {
         }
       );
     });
+    var badInput;
+    try {
+      badInput = JSON.parse(fs.readFileSync(path + '/bad.json'));
+      it(dir + ': outdated uploader version errors', function(done) {
+        async.mapSeries(
+          badInput,
+          function(e, cb){
+            e._groupId = groupId;
+            dataBroker.addDatum(e, cb);
+          },
+          function(err) {
+            expect(err.text).to.equal('The minimum supported version is [0.99.0]. Version [tidepool-uploader 0.98.0] is no longer supported.');
+            expect(err.statusCode).to.equal(400);
+            expect(err.code).to.equal('outdatedVersion');
+            expect(err.errorField).to.equal('version');
+            done();
+          }
+        );
+      });
+    }
+    catch (e) {
+      if (e.code !== 'ENOENT') {
+        throw(e);
+      }
+    }
   }
   for (var i = 0; i < files.length; ++i) {
     var path = __dirname + '/' + files[i];

--- a/test/api/upload/bad.json
+++ b/test/api/upload/bad.json
@@ -1,0 +1,23 @@
+[
+    {
+        "type": "upload",
+        "computerTime": "2015-01-01T13:00:00",
+        "time": "2015-01-01T00:00:00.000Z",
+        "timezoneOffset": 780,
+        "conversionOffset": 0,
+        "timezone": "Pacific/Auckland",
+        "version": "tidepool-uploader 0.98.0",
+        "uploadId": "1234",
+        "byUser": "Bob",
+        "deviceTags": [
+            "cgm",
+            "insulin-pump"
+        ],
+        "deviceManufacturers": [
+            "Medtronic"
+        ],
+        "deviceModel": "MiniMed 530G 551",
+        "deviceId": "multiple",
+        "deviceSerialNumber": "multiple"
+    }
+]

--- a/test/schema/uploadTest.js
+++ b/test/schema/uploadTest.js
@@ -86,9 +86,6 @@ describe('schema/upload.js', function(){
       helper.expectStringField(goodObject, 'version');
       done();
     });
-    it('is rejected when the version is outdated', function(done) {
-      helper.expectRejectionAndError(badTidepoolUploaderObject, {text: 'The minimum supported version is [0.99.0]. Version [tidepool-uploader 0.1.0] is no longer supported.', code: 'outdatedVersion', errorField: 'version'}, done);
-    });
   });
 
   describe('deviceId', function(){


### PR DESCRIPTION
What it says on the tin. This is what we talked about @jh-bate, complete with a comment and a ¯\_(ツ)_/¯ emoji

I even added a new type of API ingestion test to make sure it will send back the proper error on an attempt to upload metadata with outdated version.