### PR TITLE
Use correct private pair to get raw data; fail gracefully on bad decryption

### DIFF
--- a/lib/children/carelinkLoad.js
+++ b/lib/children/carelinkLoad.js
@@ -106,39 +106,15 @@ function fetch(userId, privatePair, filename, config, cb) {
       var updates = {};
 
       var bytesPulled = 0;
-      var recordData = '';
-      var recordRegex = /DEVICE DATA \((\d+?) records\)/i;
-      var recordCount = 0;
 
       dataStream.on('data', function(chunk) {
         if (bytesPulled === 0) {
           log.info('First byte pulled from %s in %sms', type, new Date().valueOf() - startTime);
         }
         bytesPulled += chunk.length;
-
-        // Look for record count
-        if (recordData != null) {
-          recordData += chunk.toString();
-          var match = recordRegex.exec(recordData);
-          if (match && match.length) {
-            recordCount = parseInt(match[1]);
-            recordData = null;
-          }
-        }
       });
       dataStream.on('end', function() {
         log.info('All %s bytes pulled from %s in %sms', bytesPulled, type, new Date().valueOf() - startTime);
-
-        // If no records, then error (backwards compatible)
-        if (recordCount === 0) {
-          updates.status = 'error';
-          updates.reason = 'No records were found for the given time period';
-          updates.error = {
-            error: 'norecords',
-            message: 'No records were found for the given time period',
-            code: 204
-          };
-        }
       });
 
       storage.save(userId, privatePair, filename, dataStream, updates, cb);

--- a/lib/jellyfishService.js
+++ b/lib/jellyfishService.js
@@ -203,7 +203,7 @@ function createServer(serverConfig, mongoClient, seagullClient, userApiClient, g
 
       getPrivatePair(targetUserId, function(err, privatePair) {
         if (err) {
-          log.warn(err, 'Failed to get private pair for user [%s]', userId);
+          log.warn(err, 'Failed to get private pair for user [%s]', targetUserId);
           return cb({statusCode: 500, message: 'Error getting user private data'});
         }
         return cb(null, task, privatePair);

--- a/lib/jellyfishService.js
+++ b/lib/jellyfishService.js
@@ -201,7 +201,7 @@ function createServer(serverConfig, mongoClient, seagullClient, userApiClient, g
         return cb({statusCode: 403, message: 'You do not have rights to view this data'});
       }
 
-      getPrivatePair(userId, function(err, privatePair) {
+      getPrivatePair(targetUserId, function(err, privatePair) {
         if (err) {
           log.warn(err, 'Failed to get private pair for user [%s]', userId);
           return cb({statusCode: 500, message: 'Error getting user private data'});

--- a/lib/storage/aws/s3.js
+++ b/lib/storage/aws/s3.js
@@ -58,6 +58,9 @@ module.exports = function(aws, env, storage, storageConfig) {
       var key = fileConfig.key;
       if (fileConfig.encryption != 'none') {
         key = storage.decrypt(new Buffer(key, 'hex'), 'aes256', privatePair);
+        if (!key) {
+          return cb('Failed to decrypt storage configuration', null);
+        }
       }
 
       new aws.S3({

--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -85,10 +85,15 @@ module.exports = function(env) {
       pre.notNull(encryption);
       pre.notNull(privatePair);
 
-      var decipher = crypto.createDecipher(encryption, this.calculateEncryptionKey(privatePair));
-      decipher.write(value);
-      decipher.end();
-      return decipher.read().toString();
+      try {
+        var decipher = crypto.createDecipher(encryption, this.calculateEncryptionKey(privatePair));
+        decipher.write(value);
+        decipher.end();
+        return decipher.read().toString();
+      } catch (err) {
+        log.error('Failed to decrypt value using specified encryption and private pair', err)
+        return null;
+      }
     }
   };
 };

--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -91,7 +91,7 @@ module.exports = function(env) {
         decipher.end();
         return decipher.read().toString();
       } catch (err) {
-        log.error('Failed to decrypt value using specified encryption and private pair', err)
+        log.error('Failed to decrypt value using specified encryption and private pair', err);
         return null;
       }
     }

--- a/lib/storage/local.js
+++ b/lib/storage/local.js
@@ -54,6 +54,9 @@ module.exports = function(storage, storageConfig) {
       var filePath = fileConfig.path;
       if (fileConfig.encryption != 'none') {
         filePath = storage.decrypt(new Buffer(filePath, 'hex'), 'aes256', privatePair);
+        if (!filePath) {
+          return cb('Failed to decrypt storage configuration', null);
+        }
       }
 
       fs.open(filePath, 'r', function(err, fd) {


### PR DESCRIPTION
Silly error on my part using the wrong user's private pair for decryption. Added additional protection against unexpected decryption failure (which shouldn't ever happen).

@jebeck @jh-bate 