### PR TITLE
Do not require AWS credentials if provided by EC2 role; fix memory settings

### DIFF
--- a/lib/storage/aws/s3.js
+++ b/lib/storage/aws/s3.js
@@ -17,6 +17,7 @@
 
 'use strict';
 
+var _ = require('lodash');
 var crypto = require('crypto');
 var path = require('path');
 var stream = require('stream');
@@ -32,10 +33,8 @@ var log = require('../../log.js')('storage/aws/s3.js');
 module.exports = function(aws, env, storage, storageConfig) {
   pre.notNull(aws);
   pre.notNull(env);
-  pre.notNull(storage);
   var awsCredentials = pre.hasProperty(env, 'awsCredentials');
-  var accessKeyId = pre.hasProperty(awsCredentials, 'accessKeyId');
-  var secretAccessKey = pre.hasProperty(awsCredentials, 'secretAccessKey');
+  pre.notNull(storage);
   pre.notNull(storageConfig);
   var type = pre.hasProperty(storageConfig, 'type');
   var encryption = pre.hasProperty(storageConfig, 'encryption');
@@ -63,12 +62,10 @@ module.exports = function(aws, env, storage, storageConfig) {
         }
       }
 
-      new aws.S3({
-        accessKeyId: accessKeyId,
-        secretAccessKey: secretAccessKey,
+      new aws.S3(_.merge(awsCredentials, {
         region: fileConfig.region,
         sslEnabled: true
-      }).getObject({
+      })).getObject({
         Bucket: fileConfig.bucket,
         Key: key
       }).send(function(err, data) {
@@ -106,12 +103,10 @@ module.exports = function(aws, env, storage, storageConfig) {
 
       log.info('Uploading data to AWS S3 to region [%s] for bucket [%s] and key [%s]', region, bucket, key);
 
-      new aws.S3({
-        accessKeyId: accessKeyId,
-        secretAccessKey: secretAccessKey,
+      new aws.S3(_.merge(awsCredentials, {
         region: region,
         sslEnabled: true
-      }).upload({
+      })).upload({
         Bucket: bucket,
         Key: key,
         Body: dataStream.pipe(new stream.PassThrough())

--- a/start.sh
+++ b/start.sh
@@ -3,4 +3,4 @@
 export SERVE_STATIC=dist
 
 . config/env.sh
-exec node --trace_gc --max_old_space_size=128 app.js
+exec node app.js


### PR DESCRIPTION
@jh-bate @jebeck If I could get a quick review on this so I can continue setting up the new cluster.  The AWS credential changes are backwards compatible and only affect the new cluster with EC2 roles assigned to each instance. It still works as normal in the old clusters or locally. The second one is necessary to give Jellyfish enough memory to function well (without GC'ing all the day long).