### PR TITLE
minor changes to schema validation for Tandem ingestion

### DIFF
--- a/lib/schema/basal.js
+++ b/lib/schema/basal.js
@@ -116,7 +116,7 @@ module.exports = function(streamDAO){
         {
           schema: {
             deviceTime: schema.validDeviceTime,
-            scheduleName: schema.isString,
+            scheduleName: schema.ifExists(schema.isString),
             rate: schema.isNumber,
             duration: schema.ifExists(schema.and(schema.isNumber, schema.greaterThanEq(0))),
             previous: schema.ifExists(schema.or(schema.isObject, schema.isString)),

--- a/lib/schema/pumpSettings.js
+++ b/lib/schema/pumpSettings.js
@@ -55,6 +55,7 @@ var insulinSensitivitySchema = schema.isArrayWithValueSchema({
 });
 
 var bgTargetSchema = schema.or(
+  schema.ensureSchemaFn('bgTarget', { target: schema.isNumber }),
   schema.ensureSchemaFn('bgTarget', { target: schema.ifExists(schema.isNumber), low: schema.isNumber, high: schema.isNumber }),
   schema.ensureSchemaFn('bgTarget', { target: schema.isNumber, range: schema.isNumber }),
   schema.ensureSchemaFn('bgTarget', { target: schema.isNumber, high: schema.isNumber })

--- a/lib/schema/pumpSettings.js
+++ b/lib/schema/pumpSettings.js
@@ -56,7 +56,7 @@ var insulinSensitivitySchema = schema.isArrayWithValueSchema({
 
 var bgTargetSchema = schema.or(
   schema.ensureSchemaFn('bgTarget', { target: schema.isNumber }),
-  schema.ensureSchemaFn('bgTarget', { target: schema.ifExists(schema.isNumber), low: schema.isNumber, high: schema.isNumber }),
+  schema.ensureSchemaFn('bgTarget', { low: schema.isNumber, high: schema.isNumber }),
   schema.ensureSchemaFn('bgTarget', { target: schema.isNumber, range: schema.isNumber }),
   schema.ensureSchemaFn('bgTarget', { target: schema.isNumber, high: schema.isNumber })
 );

--- a/lib/schema/wizard.js
+++ b/lib/schema/wizard.js
@@ -24,12 +24,12 @@ var idFields = ['type', 'deviceId', 'time'];
 schema.registerIdFields('wizard', idFields);
 
 var recommendedSchema = schema.and(
-    schema.isObject,
-    schema.ensureSchemaFn('recommended', {
-        carb: schema.ifExists(schema.isNumber),
-        correction: schema.ifExists(schema.isNumber),
-        net: schema.ifExists(schema.isNumber)
-       }
+  schema.isObject,
+  schema.ensureSchemaFn('recommended', {
+      carb: schema.ifExists(schema.isNumber),
+      correction: schema.ifExists(schema.isNumber),
+      net: schema.ifExists(schema.isNumber)
+    }
   )
 );
 

--- a/test/api/basal/input.json
+++ b/test/api/basal/input.json
@@ -146,7 +146,6 @@
     "conversionOffset": 0,
     "type": "basal",
     "deliveryType": "scheduled",
-    "scheduleName": "Standard",
     "rate": 2.0,
     "duration": 18000000,
     "deviceId": "tools",

--- a/test/api/basal/output.json
+++ b/test/api/basal/output.json
@@ -198,7 +198,6 @@
         "conversionOffset": 0,
         "type": "basal",
         "deliveryType": "scheduled",
-        "scheduleName": "Standard",
         "rate": 2,
         "duration": 18000000,
         "deviceId": "tools",

--- a/test/schema/basalTest.js
+++ b/test/schema/basalTest.js
@@ -106,7 +106,6 @@ describe('schema/basal.js', function(){
     var goodObject = {
       type: 'basal',
       deliveryType: 'scheduled',
-      scheduleName: 'Pattern A',
       rate: 1.0,
       duration: 7200000,
       deviceTime: '2014-01-01T03:00:00',
@@ -242,7 +241,7 @@ describe('schema/basal.js', function(){
     });
 
     describe('scheduleName', function(){
-      helper.rejectIfAbsent(goodObject, 'scheduleName');
+      helper.okIfAbsent(goodObject, 'scheduleName');
       helper.expectStringField(goodObject, 'scheduleName');
     });
 

--- a/test/schema/pumpSettingsTest.js
+++ b/test/schema/pumpSettingsTest.js
@@ -218,6 +218,7 @@ describe('schema/pumpSettings.js', function () {
     });
   });
 
+  // Tandem
   describe('bgTargets', function() {
     var multiBgTargets = _.cloneDeep(goodObject);
     delete multiBgTargets.bgTarget;
@@ -240,19 +241,17 @@ describe('schema/pumpSettings.js', function () {
       multiConvert.units.bg = 'mg/dL';
       multiConvert.bgTargets = { 
         "weekday": [
-          { low: 80, high: 100, target: 90, start: 0 },
-          { low: 90, high: 110, target: 100, start: 10800000 }
+          { target: 90, start: 0 },
+          { target: 100, start: 10800000 }
         ],
         "weekend": [
-          { low: 80, high: 100, target: 90, start: 0 },
-          { low: 90, high: 110, target: 100, start: 10800000 }
+          { target: 90, start: 0 },
+          { target: 100, start: 21600000 }
         ]};
       helper.run(multiConvert, function(err, converted) {
         if (err != null) {
           return done(err);
         }
-        expect(converted.bgTargets.weekday[0].low).equals(4.440598392836427);
-        expect(converted.bgTargets.weekend[1].high).equals(6.1058227901500866);
         expect(converted.bgTargets.weekend[0].target).equals(4.9956731919409805);
         done(err);
       });
@@ -264,6 +263,7 @@ describe('schema/pumpSettings.js', function () {
     helper.rejectIfNeither(goodObject, 'bgTarget', 'bgTargets');
     helper.expectObjectField(goodObject, 'bgTarget');
 
+    // Medtronic
     describe('(Target) + High/Low', function(){
       var localGood = {};
       beforeEach(function(){
@@ -313,6 +313,7 @@ describe('schema/pumpSettings.js', function () {
       });
     });
 
+    // Animas
     describe('Target + Range', function(){
       var localGood = {};
 
@@ -362,6 +363,7 @@ describe('schema/pumpSettings.js', function () {
       });
     });
 
+    // OmniPod
     describe('Target + High', function(){
       var localGood = {};
 

--- a/test/schema/wizardTest.js
+++ b/test/schema/wizardTest.js
@@ -98,34 +98,7 @@ describe('schema/wizard.js', function(){
       });
     });
 
-    describe('(Target) + High/Low', function(){
-      var localGood = {};
-      beforeEach(function(){
-        localGood = _.cloneDeep(goodObject);
-      });
-
-      it('accepts a bgTarget with a target', function(done){
-        localGood.bgTarget.target = 4.5;
-        helper.run(localGood, done);
-      });
-
-      it('converts units', function(done){
-        localGood.units = 'mg/dL';
-        localGood.bgTarget = { low: 80, high: 100, target: 90 };
-
-        helper.run(localGood, function(err, converted) {
-          if (err != null) {
-            return done(err);
-          }
-
-          expect(converted.bgTarget).deep.equals(
-            { low: 4.440598392836427, high: 5.550747991045533, target: 4.9956731919409805 }
-          );
-          done();
-        });
-      });
-    });
-
+    // Animas pumps
     describe('Target + Range', function(){
       var localGood = {};
 
@@ -150,6 +123,7 @@ describe('schema/wizard.js', function(){
       });
     });
 
+    // OmniPod
     describe('Target + High', function(){
       var localGood = {};
 
@@ -174,6 +148,7 @@ describe('schema/wizard.js', function(){
       });
     });
 
+    // Tandem
     describe('Target (only!)', function(){
       var localGood = {};
 

--- a/test/schema/wizardTest.js
+++ b/test/schema/wizardTest.js
@@ -173,6 +173,30 @@ describe('schema/wizard.js', function(){
         });
       });
     });
+
+    describe('Target (only!)', function(){
+      var localGood = {};
+
+      beforeEach(function(){
+        localGood = _.cloneDeep(goodObject);
+        localGood.bgTarget = { target: 4.5 };
+      });
+
+      it('accepts the good', function(done){
+        helper.run(localGood, done);
+      });
+
+      it('converts units', function(done){
+        localGood.bgTarget = { target: 100 };
+
+        helper.run(localGood, function(err, converted) {
+          expect(converted.bgTarget).deep.equals(
+            { target: 5.550747991045533 }
+          );
+          done(err);
+        });
+      });
+    });
   });
 
   describe('bolus', function(){


### PR DESCRIPTION
**WIP** Don't merge!

Small changes to diabetes device data schemas necessary for Tandem (and other current & upcoming pump drivers).

Changes:

- [x] make `scheduleName` optional on scheduled basals
- [x] add a minimal `{target: 100}` "shape" for bgTarget in wizards
- [x] add a minimal `{start: 0, target: 100}` "shape" for bgTarget in pumpSettings
- [x] remove non-existent `{target: 100, low: 80, high: 120}` "shape" for bgTarget in wizards and pumpSettings