### PR TITLE
replace final basal fabricated from schedule

### DIFF
--- a/lib/schema/basal.js
+++ b/lib/schema/basal.js
@@ -30,8 +30,26 @@ var mismatchedSeries = 'basal/mismatched-series';
 
 function adjustDuration(curr, prev) {
   var actualDuration = Date.parse(curr.time) - Date.parse(prev.time);
+  var findFabricatedBasalAnnotation = function(ann) {
+    return ann.code === 'final-basal/fabricated-from-schedule';
+  };
+  var fabricatedAnnotation = _.find(prev.annotations || [], findFabricatedBasalAnnotation);
   if (actualDuration < prev.duration) {
-    return _.assign({}, prev, { duration: actualDuration, expectedDuration: prev.duration });
+    return _.assign({}, prev, {
+      duration: actualDuration,
+      expectedDuration: prev.duration
+    });
+  } else if ((actualDuration > prev.duration) && fabricatedAnnotation !== undefined) {
+    var newPrev = _.assign({}, prev, {
+      duration: actualDuration,
+      annotations: _.reject(prev.annotations, findFabricatedBasalAnnotation)
+    });
+    if (_.isEmpty(newPrev.annotations)) {
+      return _.omit(newPrev, 'annotations');
+    }
+    else {
+      return newPrev;
+    }
   } else {
     return prev;
   }


### PR DESCRIPTION
Replace final basal fabricated from schedule with actual duration on next upload, removing annotation. This will apply to any insulin pump that uses our "common" factored-out final basal code, right now including Insulet and Tandem. Won't have an effect until [uploader PR 198](https://github.com/tidepool-org/chrome-uploader/pull/198).