### PR TITLE
handle adjustments to previous final basal (and removing annotation) …

### DIFF
--- a/lib/schema/basal.js
+++ b/lib/schema/basal.js
@@ -34,22 +34,24 @@ function adjustDuration(curr, prev) {
     return ann.code === 'final-basal/fabricated-from-schedule';
   };
   var fabricatedAnnotation = _.find(prev.annotations || [], findFabricatedBasalAnnotation);
-  if (actualDuration < prev.duration) {
+  if (fabricatedAnnotation !== undefined) {
+    if (actualDuration !== prev.duration) {
+      var newPrev = _.assign({}, prev, {
+        duration: actualDuration,
+        annotations: _.reject(prev.annotations, findFabricatedBasalAnnotation)
+      });
+      if (_.isEmpty(newPrev.annotations)) {
+        return _.omit(newPrev, 'annotations');
+      }
+      else {
+        return newPrev;
+      }
+    }
+  } else if (actualDuration < prev.duration) {
     return _.assign({}, prev, {
       duration: actualDuration,
       expectedDuration: prev.duration
     });
-  } else if ((actualDuration > prev.duration) && fabricatedAnnotation !== undefined) {
-    var newPrev = _.assign({}, prev, {
-      duration: actualDuration,
-      annotations: _.reject(prev.annotations, findFabricatedBasalAnnotation)
-    });
-    if (_.isEmpty(newPrev.annotations)) {
-      return _.omit(newPrev, 'annotations');
-    }
-    else {
-      return newPrev;
-    }
   } else {
     return prev;
   }


### PR DESCRIPTION
Handle adjustments to previous final basal (and removing annotation) when final basal lenghtened *or* cut short. Also added more tests (for when the current to the previous is a temp or suspend, not just scheduled).

Submitted for your consideration by [Major Major Major Major](https://en.wikipedia.org/wiki/Major_Major_Major_Major), @jh-bate 