### PR TITLE
Sprint 24 version check

### DIFF
--- a/lib/jellyfishService.js
+++ b/lib/jellyfishService.js
@@ -140,11 +140,11 @@ function createServer(serverConfig, mongoClient, seagullClient, userApiClient, g
     log.info('Handling versions request');
 
     var expectedVersions = {
-      schemaMinimum : schemaEnv.schemaVersion,
-      uploaderMinimum : schemaEnv.minimumUploaderVersion
+      versions: {
+        schemaMinimum : schemaEnv.schemaVersion,
+        uploaderMinimum : schemaEnv.minimumUploaderVersion
+      }
     };
-
-    console.log('versions', expectedVersions );
 
     response.status(200).send(expectedVersions);
   });

--- a/lib/jellyfishService.js
+++ b/lib/jellyfishService.js
@@ -141,7 +141,7 @@ function createServer(serverConfig, mongoClient, seagullClient, userApiClient, g
 
     var expectedVersions = {
       versions: {
-        schemaMinimum : schemaEnv.schemaVersion,
+        schema : schemaEnv.schemaVersion,
         uploaderMinimum : schemaEnv.minimumUploaderVersion
       }
     };

--- a/lib/jellyfishService.js
+++ b/lib/jellyfishService.js
@@ -23,6 +23,7 @@ var log = require('./log.js')('jellyfishService.js');
 
 var async = require('async');
 var env = require('../env.js');
+var schemaEnv = require('./schema/schemaEnv.js');
 var express = require('express');
 var compression = require('compression');
 var bodyparser = require('body-parser');
@@ -133,6 +134,19 @@ function createServer(serverConfig, mongoClient, seagullClient, userApiClient, g
   app.get('/status', function(request, response) {
     log.info('Handling status request');
     response.status(200).send('OK');
+  });
+
+  app.get('/info', function(request, response) {
+    log.info('Handling versions request');
+
+    var expectedVersions = {
+      schemaMinimum : schemaEnv.schemaVersion,
+      uploaderMinimum : schemaEnv.minimumUploaderVersion
+    };
+
+    console.log('versions', expectedVersions );
+
+    response.status(200).send(expectedVersions);
   });
 
   function parseParameters(request, cb) {


### PR DESCRIPTION
@darinkrauss  here is the PR for the addition of info endpoint that that will return details on the expected versions. This endpoint is unsecured 

so `http://localhost:8009/upload/info`

will return 

```
{ versions: { schema:1, uploaderMinimum :"0.250.0"}}
```
