### PR TITLE
Adding a missing return path for when duration is equal

### DIFF
--- a/lib/schema/basal.js
+++ b/lib/schema/basal.js
@@ -46,6 +46,8 @@ function adjustDuration(curr, prev) {
       else {
         return newPrev;
       }
+    } else {
+        return prev;
     }
   } else if (actualDuration < prev.duration) {
     return _.assign({}, prev, {

--- a/lib/schema/basal.js
+++ b/lib/schema/basal.js
@@ -48,7 +48,15 @@ function adjustDuration(curr, prev) {
       }
     }
     else {
-      return prev;
+      var newPrev = _.assign({}, prev, {
+        annotations: _.reject(prev.annotations, findFabricatedBasalAnnotation)
+      });
+      if (_.isEmpty(newPrev.annotations)) {
+        return _.omit(newPrev, 'annotations');
+      }
+      else {
+        return newPrev;
+      }
     }
   }
   else if (actualDuration < prev.duration) {
@@ -114,7 +122,7 @@ module.exports = function(streamDAO){
 
         if (actualPrev != null) {
           var adjustedPrev = adjustDuration(datum, actualPrev);
-          if (adjustedPrev != null && adjustedPrev.duration !== actualPrev.duration) {
+          if (adjustedPrev != null && !_.isEqual(adjustedPrev, actualPrev)) {
             eventsToStore.push(adjustedPrev);
           }
           done();

--- a/lib/schema/basal.js
+++ b/lib/schema/basal.js
@@ -48,14 +48,14 @@ function adjustDuration(curr, prev) {
       }
     }
     else {
-      var newPrev = _.assign({}, prev, {
+      var newPrevSameDuration = _.assign({}, prev, {
         annotations: _.reject(prev.annotations, findFabricatedBasalAnnotation)
       });
-      if (_.isEmpty(newPrev.annotations)) {
-        return _.omit(newPrev, 'annotations');
+      if (_.isEmpty(newPrevSameDuration.annotations)) {
+        return _.omit(newPrevSameDuration, 'annotations');
       }
       else {
-        return newPrev;
+        return newPrevSameDuration;
       }
     }
   }

--- a/lib/schema/basal.js
+++ b/lib/schema/basal.js
@@ -46,15 +46,21 @@ function adjustDuration(curr, prev) {
       else {
         return newPrev;
       }
-    } else {
-        return prev;
     }
-  } else if (actualDuration < prev.duration) {
+    else {
+      return prev;
+    }
+  }
+  else if (actualDuration < prev.duration) {
     return _.assign({}, prev, {
       duration: actualDuration,
       expectedDuration: prev.duration
     });
-  } else {
+  }
+  // NB: we *intentionally* do not update the duration if actualDuration > prev.duration
+  // because that could happen in situtations like the pump not being used for a month
+  // in which case we would update the actualDuration to (falsely) be ~a month in duration
+  else {
     return prev;
   }
 }
@@ -84,10 +90,13 @@ module.exports = function(streamDAO){
           }
 
           if (annotate) {
-            eventsToStore.push(schema.annotateEvent(
-              adjustDuration(datum, disjointPrev),
-              { code: mismatchedSeries, nextId: schema.generateId(datum, idFields) }
-            ));
+            var adjustedPrev = adjustDuration(datum, disjointPrev);
+            if (adjustedPrev != null) {
+              eventsToStore.push(schema.annotateEvent(
+                adjustedPrev,
+                { code: mismatchedSeries, nextId: schema.generateId(datum, idFields) }
+              ));
+            }
           }
         }
         done();
@@ -105,7 +114,7 @@ module.exports = function(streamDAO){
 
         if (actualPrev != null) {
           var adjustedPrev = adjustDuration(datum, actualPrev);
-          if (adjustedPrev.duration !== actualPrev.duration) {
+          if (adjustedPrev != null && adjustedPrev.duration !== actualPrev.duration) {
             eventsToStore.push(adjustedPrev);
           }
           done();

--- a/test/schema/basalTest.js
+++ b/test/schema/basalTest.js
@@ -294,8 +294,11 @@ describe('schema/basal.js', function(){
           var localGoodObject = _.assign({}, goodObject);
           var expectedPrevious = _.assign({}, previousMatches);
 
-          helper.run(localGoodObject, function(err, obj){
-            expect(_.pick(obj, Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
+          helper.run(localGoodObject, function(err, objs){
+            expect(objs).length(2);
+
+            expect(_.pick(objs[0], Object.keys(expectedPrevious))).deep.equals(expectedPrevious);
+            expect(_.pick(objs[1], Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
 
             return done(err);
           });
@@ -480,8 +483,11 @@ describe('schema/basal.js', function(){
           var localGoodObject = _.assign({}, goodObject);
           var expectedPrevious = _.assign({}, previousMatches);
 
-          helper.run(localGoodObject, function(err, obj){
-            expect(_.pick(obj, Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
+          helper.run(localGoodObject, function(err, objs){
+            expect(objs).length(2);
+
+            expect(_.pick(objs[0], Object.keys(expectedPrevious))).deep.equals(expectedPrevious);
+            expect(_.pick(objs[1], Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
 
             return done(err);
           });
@@ -689,8 +695,11 @@ describe('schema/basal.js', function(){
           var localGoodObject = _.assign({}, goodObject);
           var expectedPrevious = _.assign({}, previousMatches);
 
-          helper.run(localGoodObject, function(err, obj){
-            expect(_.pick(obj, Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
+          helper.run(localGoodObject, function(err, objs){
+            expect(objs).length(2);
+
+            expect(_.pick(objs[0], Object.keys(expectedPrevious))).deep.equals(expectedPrevious);
+            expect(_.pick(objs[1], Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
 
             return done(err);
           });

--- a/test/schema/basalTest.js
+++ b/test/schema/basalTest.js
@@ -289,6 +289,17 @@ describe('schema/basal.js', function(){
             return done(err);
           });
         });
+
+        it('does not update the duration of previous final basal events if the new event has the same duration', function(done){
+          var localGoodObject = _.assign({}, goodObject);
+          var expectedPrevious = _.assign({}, previousMatches);
+
+          helper.run(localGoodObject, function(err, obj){
+            expect(_.pick(obj, Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
+
+            return done(err);
+          });
+        });
       });
     });
 
@@ -418,6 +429,59 @@ describe('schema/basal.js', function(){
 
             expect(_.pick(objs[0], Object.keys(expectedPrevious))).deep.equals(expectedPrevious);
             expect(_.pick(objs[1], Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
+
+            return done(err);
+          });
+        });
+      });
+
+      describe('previous [final basal]', function(){
+        var prevId = schema.makeId(previousMatches);
+
+        beforeEach(function(){
+          helper.resetMocks();
+          sinon.stub(helper.streamDAO, 'getDatum');
+          helper.streamDAO.getDatum
+            .withArgs(prevId, goodObject._groupId, sinon.match.func)
+            .callsArgWith(2, null, _.assign({}, previousMatches, {
+              annotations: [{code: 'final-basal/fabricated-from-schedule'}]
+            }));
+        });
+
+        it('updates the duration of previous final basal events if the new event extends the previous longer than fabricated', function(done){
+          var localGoodObject = _.assign({}, goodObject, {time: '2014-01-01T01:02:00.000Z'});
+          var expectedPrevious = _.assign({}, previousMatches, {duration: 3720000});
+
+          helper.run(localGoodObject, function(err, objs){
+            expect(objs).length(2);
+
+            expect(_.pick(objs[0], Object.keys(expectedPrevious))).deep.equals(expectedPrevious);
+            expect(_.pick(objs[1], Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
+
+            return done(err);
+          });
+        });
+
+        it('updates the duration of previous final basal events if the new event cuts the previous short', function(done){
+          var localGoodObject = _.assign({}, goodObject, {time: '2014-01-01T00:58:00.000Z'});
+          var expectedPrevious = _.assign({}, previousMatches, {duration: 3480000});
+
+          helper.run(localGoodObject, function(err, objs){
+            expect(objs).length(2);
+
+            expect(_.pick(objs[0], Object.keys(expectedPrevious))).deep.equals(expectedPrevious);
+            expect(_.pick(objs[1], Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
+
+            return done(err);
+          });
+        });
+
+        it('does not update the duration of previous final basal events if the new event has the same duration', function(done){
+          var localGoodObject = _.assign({}, goodObject);
+          var expectedPrevious = _.assign({}, previousMatches);
+
+          helper.run(localGoodObject, function(err, obj){
+            expect(_.pick(obj, Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
 
             return done(err);
           });
@@ -616,6 +680,17 @@ describe('schema/basal.js', function(){
 
             expect(_.pick(objs[0], Object.keys(expectedPrevious))).deep.equals(expectedPrevious);
             expect(_.pick(objs[1], Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
+
+            return done(err);
+          });
+        });
+
+        it('does not update the duration of previous final basal events if the new event has the same duration', function(done){
+          var localGoodObject = _.assign({}, goodObject);
+          var expectedPrevious = _.assign({}, previousMatches);
+
+          helper.run(localGoodObject, function(err, obj){
+            expect(_.pick(obj, Object.keys(localGoodObject))).deep.equals(_.omit(localGoodObject, 'previous'));
 
             return done(err);
           });


### PR DESCRIPTION
In `adjustDuration` in `basal.js`, when `actualDuration == prev.duration` nothing is returned, resulting in an `undefined` for  `var adjustedPrev = adjustDuration(datum, actualPrev);`.

This fix now returns `prev` when durations are equal.

