### PR TITLE
relax time validation, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - "0.12.0"
+  - "0.12.7"
   - "stable"
 services: mongodb
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: false
+
 language: node_js
 node_js:
-  - "0.12"
+  - "0.12.0"
   - "stable"
 services: mongodb
 script:

--- a/lib/schema/cbg.js
+++ b/lib/schema/cbg.js
@@ -24,6 +24,7 @@ schema.registerIdFields('cbg', idFields);
 
 module.exports = schema.makeHandler('cbg', {
   schema: {
+  	// no longer required because of HealthKit integration
     deviceTime: schema.ifExists(schema.validDeviceTime),
     value: schema.isNumber,
     isig: schema.ifExists(schema.isNumber),

--- a/lib/schema/cbg.js
+++ b/lib/schema/cbg.js
@@ -24,7 +24,7 @@ schema.registerIdFields('cbg', idFields);
 
 module.exports = schema.makeHandler('cbg', {
   schema: {
-    deviceTime: schema.validDeviceTime,
+    deviceTime: schema.ifExists(schema.validDeviceTime),
     value: schema.isNumber,
     isig: schema.ifExists(schema.isNumber),
     units: schema.in('mmol/L', 'mmol/l', 'mg/dL', 'mg/dl')

--- a/lib/schema/schema.js
+++ b/lib/schema/schema.js
@@ -342,9 +342,11 @@ exports.removeAnnotation = function(event, ann) {
 };
 
 var baseChecks = {
+  deviceTime: exports.ifExists(exports.validDeviceTime),
   time: exports.validTimestamp,
-  timezoneOffset: exports.isNumber,
-  conversionOffset: exports.isNumber,
+  timezoneOffset: exports.ifExists(exports.isNumber),
+  conversionOffset: exports.ifExists(exports.isNumber),
+  clockDriftOffset: exports.ifExists(exports.isNumber),
   deviceId: exports.isString,
   uploadId: exports.isString,
   _active: exports.doesNotExist,

--- a/lib/schema/upload.js
+++ b/lib/schema/upload.js
@@ -39,6 +39,11 @@ module.exports = schema.makeHandler('upload', {
     deviceManufacturers: schema.isArrayWithValueSchema(schema.isString),
     deviceModel: schema.isString,
     deviceSerialNumber: schema.isString,
+    timeProcessing: schema.in(
+      'across-the-board-timezone',
+      'utc-bootstrapping',
+      'none'
+    ),
     version: schema.isString
   }
 });

--- a/test/api/cbg/input.json
+++ b/test/api/cbg/input.json
@@ -32,5 +32,13 @@
         "units": "mg/dl",
         "deviceId": "tools",
         "uploadId": "tools"
+    },
+    {
+        "time": "2015-12-21T11:23:08Z",
+        "type": "cbg",
+        "value": 69,
+        "units": "mg\/dL",
+        "deviceId": "DexHealthKit_Dexcom:com.dexcom.Share2:3.0.4.17",
+        "uploadId": "upid_HealthKit_org.tidepool.blipnotes:1.1:242_2016-03-10T10:25:55-06:00"
     }
 ]

--- a/test/api/cbg/output.json
+++ b/test/api/cbg/output.json
@@ -47,5 +47,18 @@
         "_version": 0,
         "_active": true,
         "_schemaVersion": 0
+    },
+    {
+        "time": "2015-12-21T11:23:08Z",
+        "type": "cbg",
+        "value": 3.830016113821418,
+        "units": "mmol/L",
+        "deviceId": "DexHealthKit_Dexcom:com.dexcom.Share2:3.0.4.17",
+        "uploadId": "upid_HealthKit_org.tidepool.blipnotes:1.1:242_2016-03-10T10:25:55-06:00",
+        "_groupId": "1234",
+        "id": "nsikjhfaprplpq78hc7di2lu5qpt1e3k",
+        "_version": 0,
+        "_active": true,
+        "_schemaVersion": 0
     }
 ]

--- a/test/api/upload/input.json
+++ b/test/api/upload/input.json
@@ -18,6 +18,7 @@
         ],
         "deviceModel": "MiniMed 530G 551",
         "deviceId": "multiple",
-        "deviceSerialNumber": "multiple"
+        "deviceSerialNumber": "multiple",
+        "timeProcessing": "utc-bootstrapping"
     }
 ]

--- a/test/api/upload/output.json
+++ b/test/api/upload/output.json
@@ -19,6 +19,7 @@
         "deviceModel": "MiniMed 530G 551",
         "deviceId": "multiple",
         "deviceSerialNumber": "multiple",
+        "timeProcessing": "utc-bootstrapping",
         "_groupId": "1234",
         "id": "7h3jc5jj5nl3bcu1gvs4j4k442pup1ef",
         "_version": 0,

--- a/test/schema/schemaTestHelper.js
+++ b/test/schema/schemaTestHelper.js
@@ -243,7 +243,7 @@ exports.testCommonFields = function(goodObject) {
     exports.okIfAbsent(goodObject, 'conversionOffset');
 
     it('rejects non-numerical conversionOffset', function(done){
-      exports.expectRejection(_.assign({}, goodObject, {conversionOffset: '-0500'}), 'conversionOffset', done)
+      exports.expectRejection(_.assign({}, goodObject, {conversionOffset: '-0500'}), 'conversionOffset', done);
     });
   });
 
@@ -251,7 +251,7 @@ exports.testCommonFields = function(goodObject) {
     exports.okIfAbsent(goodObject, 'clockDriftOffset');
 
     it('rejects non-numerical clockDriftOffset', function(done){
-      exports.expectRejection(_.assign({}, goodObject, {clockDriftOffset: '-123456'}), 'clockDriftOffset', done)
+      exports.expectRejection(_.assign({}, goodObject, {clockDriftOffset: '-123456'}), 'clockDriftOffset', done);
     });
   });
 
@@ -273,7 +273,7 @@ exports.testCommonFields = function(goodObject) {
     exports.okIfAbsent(goodObject, '_active');
 
     it('rejects data with _active set', function(done){
-      exports.expectRejection(_.assign({}, goodObject, {_active: true}), '_active', done)
+      exports.expectRejection(_.assign({}, goodObject, {_active: true}), '_active', done);
     });
   });
 
@@ -281,7 +281,7 @@ exports.testCommonFields = function(goodObject) {
     exports.okIfAbsent(goodObject, '_version');
 
     it('rejects data with _version set', function(done){
-      exports.expectRejection(_.assign({}, goodObject, {_version: 2}), '_version', done)
+      exports.expectRejection(_.assign({}, goodObject, {_version: 2}), '_version', done);
     });
   });
 
@@ -289,7 +289,7 @@ exports.testCommonFields = function(goodObject) {
     exports.okIfAbsent(goodObject, '_schemaVersion');
 
     it('rejects data with _schemaVersion set', function(done){
-      exports.expectRejection(_.assign({}, goodObject, {_schemaVersion: 2}), '_schemaVersion', done)
+      exports.expectRejection(_.assign({}, goodObject, {_schemaVersion: 2}), '_schemaVersion', done);
     });
   });
 };

--- a/test/schema/schemaTestHelper.js
+++ b/test/schema/schemaTestHelper.js
@@ -215,7 +215,7 @@ exports.testCommonFields = function(goodObject) {
   });
 
   describe('timezoneOffset', function(){
-    exports.rejectIfAbsent(goodObject, 'timezoneOffset');
+    exports.okIfAbsent(goodObject, 'timezoneOffset');
     it('rejects non-numerical timezoneOffset', function(done){
       exports.expectRejection(_.assign({}, goodObject, {timezoneOffset: '+08:00'}), 'timezoneOffset', done);
     });

--- a/test/schema/schemaTestHelper.js
+++ b/test/schema/schemaTestHelper.js
@@ -191,6 +191,24 @@ exports.expectUnitConversion = function(goodObject, field) {
 };
 
 exports.testCommonFields = function(goodObject) {
+  describe('deviceTime', function(){
+    it('accepts timestamps in ISO 8601 format w/no timezone info', function(done){
+      exports.run(_.assign({}, goodObject, {deviceTime: '2015-01-01T00:05:25'}), function(err, val){
+        if (Array.isArray(val)) {
+          expect(val).length(1);
+          val = val[0];
+        }
+        expect(val.deviceTime).equals('2015-01-01T00:05:25');
+        done(err);
+      });
+    });
+    it('rejects non-string time', function(done){
+      exports.expectRejection(
+        _.assign({}, goodObject, {time: new Date('2014-01-01T01:01:00.000Z').valueOf()}), 'time', done
+      );
+    });
+  });
+
   describe('time', function(){
     exports.rejectIfAbsent(goodObject, 'time');
 
@@ -221,6 +239,22 @@ exports.testCommonFields = function(goodObject) {
     });
   });
 
+  describe('conversionOffset', function(){
+    exports.okIfAbsent(goodObject, 'conversionOffset');
+
+    it('rejects non-numerical conversionOffset', function(done){
+      exports.expectRejection(_.assign({}, goodObject, {conversionOffset: '-0500'}), 'conversionOffset', done)
+    });
+  });
+
+  describe('clockDriftOffset', function(){
+    exports.okIfAbsent(goodObject, 'clockDriftOffset');
+
+    it('rejects non-numerical clockDriftOffset', function(done){
+      exports.expectRejection(_.assign({}, goodObject, {clockDriftOffset: '-123456'}), 'clockDriftOffset', done)
+    });
+  });
+
   describe('deviceId', function(){
     exports.rejectIfAbsent(goodObject, 'deviceId');
     it('rejects non-string deviceId', function(done){
@@ -232,6 +266,30 @@ exports.testCommonFields = function(goodObject) {
     exports.rejectIfAbsent(goodObject, 'uploadId');
     it('rejects non-string uploadId', function(done){
       exports.expectRejection(_.assign({}, goodObject, {uploadId: 1337}), 'uploadId', done);
+    });
+  });
+
+  describe('_active', function(){
+    exports.okIfAbsent(goodObject, '_active');
+
+    it('rejects data with _active set', function(done){
+      exports.expectRejection(_.assign({}, goodObject, {_active: true}), '_active', done)
+    });
+  });
+
+  describe('_version', function(){
+    exports.okIfAbsent(goodObject, '_version');
+
+    it('rejects data with _version set', function(done){
+      exports.expectRejection(_.assign({}, goodObject, {_version: 2}), '_version', done)
+    });
+  });
+
+  describe('_schemaVersion', function(){
+    exports.okIfAbsent(goodObject, '_schemaVersion');
+
+    it('rejects data with _schemaVersion set', function(done){
+      exports.expectRejection(_.assign({}, goodObject, {_schemaVersion: 2}), '_schemaVersion', done)
     });
   });
 };

--- a/test/schema/schemaTestHelper.js
+++ b/test/schema/schemaTestHelper.js
@@ -237,6 +237,17 @@ exports.testCommonFields = function(goodObject) {
     it('rejects non-numerical timezoneOffset', function(done){
       exports.expectRejection(_.assign({}, goodObject, {timezoneOffset: '+08:00'}), 'timezoneOffset', done);
     });
+
+    it('accepts 0 as a valid timezoneOffset', function(done){
+      exports.run(_.assign({}, goodObject, {timezoneOffset: 0}), function(err, val){
+        if (Array.isArray(val)) {
+          expect(val).length(1);
+          val = val[0];
+        }
+        expect(val.timezoneOffset).equals(0);
+        done(err);
+      });      
+    });
   });
 
   describe('conversionOffset', function(){
@@ -245,6 +256,17 @@ exports.testCommonFields = function(goodObject) {
     it('rejects non-numerical conversionOffset', function(done){
       exports.expectRejection(_.assign({}, goodObject, {conversionOffset: '-0500'}), 'conversionOffset', done);
     });
+
+    it('accepts 0 as a valid conversionOffset', function(done){
+      exports.run(_.assign({}, goodObject, {conversionOffset: 0}), function(err, val){
+        if (Array.isArray(val)) {
+          expect(val).length(1);
+          val = val[0];
+        }
+        expect(val.conversionOffset).equals(0);
+        done(err);
+      });      
+    });
   });
 
   describe('clockDriftOffset', function(){
@@ -252,6 +274,17 @@ exports.testCommonFields = function(goodObject) {
 
     it('rejects non-numerical clockDriftOffset', function(done){
       exports.expectRejection(_.assign({}, goodObject, {clockDriftOffset: '-123456'}), 'clockDriftOffset', done);
+    });
+
+    it('accepts 0 as a valid clockDriftOffset', function(done){
+      exports.run(_.assign({}, goodObject, {clockDriftOffset: 0}), function(err, val){
+        if (Array.isArray(val)) {
+          expect(val).length(1);
+          val = val[0];
+        }
+        expect(val.clockDriftOffset).equals(0);
+        done(err);
+      });      
     });
   });
 

--- a/test/schema/uploadTest.js
+++ b/test/schema/uploadTest.js
@@ -139,5 +139,5 @@ describe('schema/upload.js', function(){
       obj.timeProcessing = 'foo';
       helper.expectRejection(obj, 'timeProcessing', done);
     });
-  })
+  });
 });

--- a/test/schema/uploadTest.js
+++ b/test/schema/uploadTest.js
@@ -38,6 +38,7 @@ var goodObject = {
   deviceSerialNumber: '12345',
   deviceTags: ['insulin-pump'],
   deviceId: '123-my-upload-id',
+  timeProcessing: 'utc-bootstrapping',
   _groupId: 'g'
 };
 
@@ -129,4 +130,14 @@ describe('schema/upload.js', function(){
     helper.expectStringField(goodObject, 'deviceSerialNumber');
   });
 
+  describe('timeProcessing', function() {
+    helper.rejectIfAbsent(goodObject, 'timeProcessing');
+    helper.expectStringField(goodObject, 'timeProcessing');
+
+    it('only accepts approved values', function(done) {
+      var obj = _.cloneDeep(goodObject);
+      obj.timeProcessing = 'foo';
+      helper.expectRejection(obj, 'timeProcessing', done);
+    });
+  })
 });


### PR DESCRIPTION
Changes:
- only `time` is required globally (across all device data types & upload metadata)
- in particular, `timezoneOffset` and `conversionOffset` were required and are now optional
- `deviceTime` is required on all device data types except `cbg`, where it's optional b/c of HealthKit integration
- flesh out the tests for all things globally required - for many things, there weren't any!
- `timeProcessing` on upload metadata now required and enforced to be one of three values: `utc-bootstrapping`, `across-the-board-timezone`, or `none`

Due to these changes we will be bumping `_schemaVersion` when deploying this.

@jh-bate please review.