### PR TITLE
[BACK-895] filter out nested payload suspend structures to max depth of 80

### DIFF
--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -31,6 +31,24 @@ var datumConfig = require('./schema/schemaEnv.js');
 var fiveMinutes = 5 * 60 * 1000;
 var maxRetries = 10;
 
+
+var maxSuspendedDepth = 80;
+
+function filterDatumForMongo(datum) {
+  // Filters Datum for bad characteristics.  This is a fix for problems with data that was accepted by earlier version of mongo
+  // but will cause problems for versions of mongo > 3.4.  Currently - the only problem fixed is truncating the
+  // payload.suspended nested structure to 80 levels
+  if (datum) {
+    for (var entry = datum.payload, i = 0; entry && entry.suspended; entry = entry.suspended, i++) {
+      if (i === maxSuspendedDepth) {
+        delete entry.suspended;
+        break;
+      }
+    }
+  }
+  return datum;
+}
+
 module.exports = function(mongoClient){
   function updateDatumInternal(datum, count, cb) {
     if (count >= maxRetries) {
@@ -186,10 +204,11 @@ module.exports = function(mongoClient){
       updateDatumInternal(datum, 0, cb);
     },
     addOrUpdateDatum: function(datum, cb) {
+      var filteredDatum = filterDatumForMongo(datum);
       if (datum.createdTime == null) {
-        this.insertDatum(datum, cb);
+        this.insertDatum(filteredDatum, cb);
       } else {
-        this.updateDatum(datum, cb);
+        this.updateDatum(filteredDatum, cb);
       }
     },
     storeData: function(data, cb) {


### PR DESCRIPTION
Simple fix to ensure that the payload->suspend ... structures have maximum depth of 80.

This will enable us to upgrade our mongo DB

We may find more structures that violate the 100 level deep limit.  These will be fixed in a separate PR as we find them.

Used approach of minimal touch.  Did not prune structures unless they caused problems.  We will lose data from these deeply nested structures.  If we want to keep the data  - we will have to do more work and "stringify" the offending structures.