### PR TITLE
Filter out apostrophes on insulet ominipod - BACK-1379

### DIFF
--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -51,7 +51,7 @@ function filterDatumForMongo(datum) {
     var BadDeviceIDPrefix = "InsOmn'";
     var GoodDeviceIDPrefix = "InsOmn";
     if ('deviceId' in datum && datum.deviceId.includes(BadDeviceIDPrefix)) {
-      datum.deviceId.replace(BadDeviceIDPrefix, GoodDeviceIDPrefix);
+      datum.deviceId = datum.deviceId.replace(BadDeviceIDPrefix, GoodDeviceIDPrefix);
     }
   }
   return datum;

--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -45,6 +45,14 @@ function filterDatumForMongo(datum) {
         break;
       }
     }
+
+    // This is a fix for a problem with the uploader including apostrophes for a 2 month period
+    // Jira reference - BACK-1379
+    var BadDeviceIDPrefix = "InsOmn'";
+    var GoodDeviceIDPrefix = "InsOmn";
+    if ('deviceId' in datum && datum.deviceId.includes(BadDeviceIDPrefix)) {
+      datum.deviceId.replace(BadDeviceIDPrefix, GoodDeviceIDPrefix);
+    }
   }
   return datum;
 }


### PR DESCRIPTION
Fixes issue where device ids are being written into the db from jellyfish with a spurious apostrophe for insulet ominpod devices