### PR TITLE
[BACK-1572] De-duplicate Omnipod data

### DIFF
--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -51,7 +51,7 @@ function filterDatumForMongo(datum) {
     var GoodDeviceIDPrefix = "InsOmn";
     if ('deviceId' in datum && datum.deviceId.includes(BadDeviceIDPrefix)) {
       datum.deviceId = datum.deviceId.replace(BadDeviceIDPrefix, GoodDeviceIDPrefix);
-      datum.id = schema.generateId(datum, schema.idFields(datum.type))
+      datum.id = schema.generateId(datum, schema.idFields(datum.type));
     }
   }
   return datum;

--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -24,6 +24,7 @@ var pre = require('amoeba').pre;
 
 var log = require('./log.js')('streamDAO.js');
 var misc = require('./misc.js');
+var schema = require('./schema/schema');
 
 
 var fiveMinutes = 5 * 60 * 1000;
@@ -50,6 +51,7 @@ function filterDatumForMongo(datum) {
     var GoodDeviceIDPrefix = "InsOmn";
     if ('deviceId' in datum && datum.deviceId.includes(BadDeviceIDPrefix)) {
       datum.deviceId = datum.deviceId.replace(BadDeviceIDPrefix, GoodDeviceIDPrefix);
+      datum.id = schema.generateId(datum, schema.idFields(datum.type))
     }
   }
   return datum;


### PR DESCRIPTION
Also re-generate the `id` field, which is subsequently used to generate
the `_id` field.

* FIxes [BACK-1572]

[BACK-1572]: https://tidepool.atlassian.net/browse/BACK-1572