### PR TITLE
Fix typo in future date filtering for marking summaries outdated

### DIFF
--- a/lib/dataBroker.js
+++ b/lib/dataBroker.js
@@ -37,7 +37,7 @@ function checkDatumUpdatesSummary(datum) {
   twoYearsPast.setDate(twoYearsPast.getDate() - 20);
 
   var oneDayFuture = new Date();
-  oneDayFuture.setDate(oneDayFuture.getDate() - 20);
+  oneDayFuture.setDate(oneDayFuture.getDate() + 1);
 
   var datumTime = new Date(datum.Time);
   if (isNaN(datumTime)) {


### PR DESCRIPTION
fix typo in future date check which resulted in every recent upload being ignored for summaries as a "future" upload