### PR TITLE
[BACK-1758] Move data uploads/datasets into their own collection.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ before_install:
 - wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-${MONGODB}.tgz -O /tmp/mongodb.tgz
 - tar -xf /tmp/mongodb.tgz
 - mkdir /tmp/data
-- ${PWD}/mongodb-linux-x86_64-ubuntu2004-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --logpath ${PWD}/mongod.log &> /dev/null &
+- ${PWD}/mongodb-linux-x86_64-ubuntu2004-${MONGODB}/bin/mongod --replSet rs0 --dbpath /tmp/data --bind_ip 127.0.0.1 --logpath ${PWD}/mongod.log &> /dev/null &
+# sleep for a few seconds so that mongod actually starts otherwise the mongo shell command we run below won't be able to connect to mongod.
+- sleep 2
+- ${PWD}/mongodb-linux-x86_64-ubuntu2004-${MONGODB}/bin/mongo --host 127.0.0.1 --port 27017 --eval 'rs.initiate()'
 - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
 
 services:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,9 @@ var jsFiles = [
 
 gulp.task('jshint', function() {
   var stream = gulp.src(jsFiles)
-    .pipe(jshint())
+    .pipe(jshint({
+      esversion: 11
+    }))
     .pipe(jshint.reporter('jshint-stylish'));
 
   if (process.env.CI) {

--- a/lib/mongo/mongoClient.js
+++ b/lib/mongo/mongoClient.js
@@ -21,6 +21,7 @@ var _ = require('lodash');
 var mongodb = require('mongodb-legacy');
 var pre = require('amoeba').pre;
 var getDatabaseName = require('amoeba').mongoUtil.getDatabaseName;
+var util = require('util');
 
 var log = require('../log.js')('mongoClient.js');
 
@@ -65,7 +66,7 @@ module.exports = function (config) {
      * Not using the callback passed to collCb will result in incorrect counts and elongated
      * `close()` times.
      *
-     * @param collection String name of the mongo collection to get
+     * @param {string} collectionName - name of the mongo collection to get
      * @param clientCb Callback from the user, if an error occurs, this will short-circuit to this callback directly.
      * @param collCb callback that is passed the collection as the first argument and a callback as the second argument,
      *   the callback passed into collCb *must* be called from collCb
@@ -91,6 +92,61 @@ module.exports = function (config) {
           clientCb.apply(null, Array.prototype.slice.call(arguments, 0));
         });
       });
+    },
+    /**
+     * Returns a collection synchronously as the newest mongodb driver no longer takes a callback.
+     * Use withCallback instead if the old callback behaviour is expected.
+     *
+     * @param {string} collectionName - name of the mongo collection to get.
+     * @returns {mongodb.Collection}
+     */
+    collection: function(collectionName) {
+      return mongoClient.db(databaseName).collection(collectionName);
+    },
+
+    /**
+     * Callback that gets the result of a call to mongoClient.transact.
+     * @callback transactCallback
+     * @param  {Error} err - error if any
+     * @param  {*} result - result if any
+     */
+
+    /**
+     * This is equivalent to the Node.js mongodb driver's WithTransactionCallback. It is an asynchronous function that is ran in a transaction and must use the supplied session in all its operations.
+     * @async
+     * @function transactFunction
+     * @param  {mongodb.ClientSession} session
+     * @return {*} - anything
+     */
+
+    /**
+     *  This is a helper around transactions that hides the setup and closing
+     *  of transaction sessions from the client while maintaining the
+     *  existing request counting logic of .withCollection.
+     *
+     * @param {transactFunction} asyncFn - Asynchronous function that will be wrapped in a transaction.
+     * @param {transactCallback} cb
+     */
+    transact: function(asyncFn, cb) {
+      async function run() {
+        const txOpts = {
+          readConcern: { level: 'majority' },
+          writeConcern: { w: 'majority', j: true }
+        };
+        const session = mongoClient.startSession();
+        try {
+          ++requestCount;
+          // Only the callback API supports automatic retries so we are using
+          // that here.
+          await session.withTransaction(asyncFn, txOpts);
+        }
+        finally {
+          await session.endSession();
+          --requestCount;
+        }
+        // All errors will be captured in callbackify and passed to cb
+      }
+      util.callbackify(run)(cb);
     },
     healthCheck() {
       return !!mongoClient && !!mongoClient.topology && !!mongoClient.topology.isConnected();
@@ -137,6 +193,20 @@ module.exports = function (config) {
               'type': 'basal',
               '_active': true,
             }
+          },
+          function (indexError) {
+            if (indexError) {
+              return cb(indexError);
+            }
+          }
+        );
+
+        mongoClient.db(databaseName).createIndex('deviceDataSets',
+          {
+            '_groupId': 1,
+            'deviceId': 1,
+            'source': 1,
+            'time': -1,
           },
           function (indexError) {
             if (indexError) {

--- a/lib/mongo/mongoClient.js
+++ b/lib/mongo/mongoClient.js
@@ -135,6 +135,10 @@ module.exports = function (config) {
     transact: function(asyncFn, cb) {
       async function run() {
         const txOpts = {
+          // Use majority read concern to get majority acknowledged
+          // modifications that have committed. Don't use snapshot as we want
+          // any reads to get any updated data that other transactions may
+          // have committed if this transaction fails and has to be retried.
           readConcern: { level: 'majority' },
           writeConcern: { w: 'majority', j: true }
         };

--- a/lib/mongo/mongoClient.js
+++ b/lib/mongo/mongoClient.js
@@ -94,8 +94,9 @@ module.exports = function (config) {
       });
     },
     /**
-     * Returns a collection synchronously as the newest mongodb driver no longer takes a callback.
-     * Use withCallback instead if the old callback behaviour is expected.
+     * Returns a collection synchronously as the newest mongodb driver no
+     * longer takes a callback. Use withCallback instead if the old callback
+     * behaviour is expected.
      *
      * @param {string} collectionName - name of the mongo collection to get.
      * @returns {mongodb.Collection}
@@ -112,7 +113,10 @@ module.exports = function (config) {
      */
 
     /**
-     * This is equivalent to the Node.js mongodb driver's WithTransactionCallback. It is an asynchronous function that is ran in a transaction and must use the supplied session in all its operations.
+     * This is equivalent to the Node.js mongodb driver's
+     * WithTransactionCallback. It is an asynchronous function that is ran in
+     * a transaction and must use the supplied session in all its
+     * operations.
      * @async
      * @function transactFunction
      * @param  {mongodb.ClientSession} session
@@ -122,7 +126,8 @@ module.exports = function (config) {
     /**
      *  This is a helper around transactions that hides the setup and closing
      *  of transaction sessions from the client while maintaining the
-     *  existing request counting logic of .withCollection.
+     *  existing request counting logic of .withCollection as well as
+     *  automatically retrying the tx in case of certain failures.
      *
      * @param {transactFunction} asyncFn - Asynchronous function that will be wrapped in a transaction.
      * @param {transactCallback} cb

--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -176,7 +176,7 @@ module.exports = function(mongoClient){
           return obj;
         }
         return mongoClient.collection('deviceData').findOne(query);
-      };
+      }
       const fn = util.callbackify(get);
       fn(cb);
     },

--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -21,6 +21,7 @@ var util = require('util');
 
 var _ = require('lodash');
 var pre = require('amoeba').pre;
+var async = require('async');
 
 var log = require('./log.js')('streamDAO.js');
 var misc = require('./misc.js');
@@ -103,96 +104,37 @@ function filterDatumForMongo(datum) {
 }
 
 module.exports = function(mongoClient){
-  function updateDatumInternal(datum, count, cb) {
-    if (count >= maxRetries) {
-      return cb(
-        { statusCode: 503, message: util.format('Too much contention, giving up update after %s tries.', count) }
-      );
-    }
+  function getCollectionName(datum) {
+    return typeof datum?.type === 'string' && datum.type.toLowerCase() === 'upload' ? 'deviceDataSets' : 'deviceData';
+  }
 
+  async function updateDatumInternal(session, collection, datum) {
     var clone = _.clone(datum);
     clone.modifiedTime = new Date();
     clone = ensureId(clone);
 
-    mongoClient.withCollection('deviceData', cb, function(coll, cb){
-      coll.findOne({_id: clone._id}, function(err, previous){
-        if (err != null) {
-          return cb(err);
-        }
+    let previous = await collection.findOne({_id: clone._id}, {session});
+    if (previous == null) {
+      throw { statusCode: 400, message: 'Asked to update a datum that doesn\'t exist' };
+    }
 
-        if (previous == null) {
-          return cb({ statusCode: 400, message: 'Asked to update a datum that doesn\'t exist' });
-        }
+    const modificationOpts = {
+      writeConcern: {j: true},
+      session: session,
+    };
 
-        previous = _.assign(previous, {
-          _id: previous._id + '_' + previous._version,
-          _archivedTime: new Date(),
-          _active: false
-        });
-
-        const modificationOpts = {
-          writeConcern: {j: true},
-        };
-
-        function updateItem() {
-          clone.createdTime = previous.createdTime;
-          clone._version = previous._version + 1;
-          clone._active = true;
-
-          coll.replaceOne({_id: clone._id}, _.omit(clone, '_id'), modificationOpts, cb);
-        }
-
-        // Insert the previous version first as an atomic operation.  This is logically the equivalent of optimistic
-        // locking and what protects us from race conditions because Mongo doesn't have transactions.
-        // Basically, if there is a race, one of them will update the previous object and the other will not.
-        // The one that fails to update the previous needs to try again.
-        coll.insertOne(previous, modificationOpts, function(error){
-          if (error != null) {
-            if (error.code === 11000) {
-              if (count === 0) {
-                return coll.findOne({_id: previous._id}, function(err, collidingPrev) {
-                  if (err != null) {
-                    return cb(err);
-                  }
-
-                  // If we are colliding with an object that was archived more than 5 minutes ago (or existed before
-                  // we started storing the _archivedTime field), then it is likely that the final update to the datum
-                  // failed for some reason.  In this case, we need to consider the previous update as lost and just
-                  // get on with our lives, which is what we do here.  We update the "_archivedTime" to reflect the
-                  // fact that this update is now taking on the archival and then update the item.
-                  if (collidingPrev._archivedTime == null || Date.now() - collidingPrev._archivedTime > fiveMinutes) {
-                    return coll.findOneAndUpdate(
-                      {_id: previous._id,
-                        $or:[{ _archivedTime: collidingPrev._archivedTime },
-                             { _archivedTime: new Date(collidingPrev._archivedTime) }
-                            ]
-                      },
-                      { $set: {_archivedTime: new Date()} },
-                      modificationOpts,
-                      function(err) {
-                        if (err != null) {
-                          return cb(err);
-                        }
-                        updateItem();
-                      }
-                    );
-                  } else {
-                    // try again
-                    return setTimeout(function(){ updateDatumInternal(datum, count + 1, cb); }, 30);
-                  }
-                });
-              } else {
-                // The thing we want to insert already existed, so we need to try again.
-                return setTimeout(function(){ updateDatumInternal(datum, count + 1, cb); }, 30);
-              }
-            }
-            cb(error);
-          }
-
-          updateItem();
-        });
-      });
+    previous = _.assign(previous, {
+      _id: previous._id + '_' + previous._version,
+      _archivedTime: new Date(),
+      _active: false
     });
+
+    await collection.insertOne(previous, modificationOpts);
+
+    clone.createdTime = previous.createdTime;
+    clone._version = previous._version + 1;
+    clone._active = true;
+    return await collection.replaceOne({_id: clone._id}, _.omit(clone, '_id'), modificationOpts);
   }
 
   function ensureId(datum) {
@@ -202,41 +144,80 @@ module.exports = function(mongoClient){
     return datum;
   }
 
+  // collections that dataSets may live in. Due to migrations, some may still
+  // be in the deviceData collection. Eventually all of them will be migrated
+  // to the deviceDataSets collection but until then, we must check both
+  // collections when trying to retrieve a dataSet. Once migration is done
+  // this should just be the single collection ['deviceDataSets']
+  const deviceDataSetCollections = ['deviceDataSets', 'deviceData'];
+
+  // collection for deviceData. This is always just a single collection but is
+  // used as an array so that we can use the same parameterized function
+  // whether we're touching a dataSet or non-dataSet datum and will just pass
+  // the appropriate array of collections to the function.
+  const deviceDataCollections = ['deviceData'];
+
+  // returns all the collections a datum may reside in based on its type.
+  // only for datum.type == "upload" will it possibly be in more than one collection due
+  // to an ongoing migration. Once this migration is complete, you can return just ['deviceDataSets']
+  // for datum.type == "upload"
+  function getCollections(datum) {
+    return typeof datum?.type === 'string' && datum.type.toLowerCase() === 'upload' ? deviceDataSetCollections : deviceDataCollections;
+  }
+
   return {
+    // I believe a datum is always meant to be type != 'upload' (?) but the ingestionApiTest.js file has
+    // datums of type: 'upload' so we need to check both collections.
     getDatum: function(id, groupId, cb) {
-      mongoClient.withCollection('deviceData', cb, function(coll, cb){
-        coll.findOne({_id: misc.generateId([id, groupId])}, function(err, result) {
-            if (err == null && result) {
-              convertDatesToLegacy(result);
-            }
+      async.map(['deviceDataSets', 'deviceData'], (collectionName, asyncCb) => {
+        mongoClient.withCollection(collectionName, asyncCb, function(coll, cb){
+          coll.findOne({_id: misc.generateId([id, groupId])}, function(err, result) {
             cb(err, result);
+          });
         });
+      }, (err, results) => {
+        if (err) {
+          return cb(err);
+        }
+        // Return the first non empty object otherwise just the first object.
+        cb(null, results.find(obj => !!obj) || results[0]);
       });
     },
     getDatumBefore: function(datum, cb) {
-      mongoClient.withCollection('deviceData', cb, function(coll, cb){
-        const find = util.callbackify(() => {
-          return coll.find({
-            $or: [{time: {$lt: datum.time}},
-                  {time: {$lt: new Date(datum.time)}}
-                 ],
-            _groupId: datum._groupId,
-            _active: true,
-            type: datum.type,
-            deviceId: datum.deviceId,
-            source: datum.source
-          })
-          .sort({ "time": -1 })
-          .limit(1)
-          .toArray();
-        });
+      // Due to migrations, a datum of type == "upload" may live in multiple
+      // collections as it is being migrated over so we need to map over
+      // possible collections and return the one with a value.
+      async.map(getCollections(datum), (collectionName, asyncCb) => {
+        mongoClient.withCollection(collectionName, asyncCb, function(coll, cb){
+          const find = util.callbackify(() => {
+            return coll.find({
+              $or: [{time: {$lt: datum.time}},
+                    {time: {$lt: new Date(datum.time)}}
+                   ],
+              _groupId: datum._groupId,
+              _active: true,
+              type: datum.type,
+              deviceId: datum.deviceId,
+              source: datum.source
+            })
+            .sort({ "time": -1 })
+            .limit(1)
+            .toArray();
+          });
 
-        find((err, arr) => {
-          if (err == null && arr[0]) {
-            convertDatesToLegacy(arr[0]);
-          }
-          return cb(err, arr[0]);
+          find((err, arr) => {
+            if (err == null && arr[0]) {
+              convertDatesToLegacy(arr[0]);
+            }
+            return cb(err, arr[0]);
+          });
         });
+      }, (err, results) => {
+        if (err) {
+          return cb(err);
+        }
+        // Return the first non empty object otherwise just the first object.
+        cb(null, results.find(obj => !!obj) || results[0]);
       });
     },
     insertDatum: function(datum, cb) {
@@ -256,17 +237,33 @@ module.exports = function(mongoClient){
 
       datum = ensureId(datum);
 
-      mongoClient.withCollection('deviceData', cb, function(coll, cb){
-        coll.insertOne(datum, function(err){
-          if (err != null) {
-            if (err.code === 11000) {
-              return cb({ statusCode: 400, errorCode: 'duplicate', message: 'received a duplicate event'});
-            }
-            return cb(err);
+      const errHandler = (err) => {
+        if (err != null) {
+          if (err.code === 11000) {
+            return cb({ statusCode: 400, errorCode: 'duplicate', message: 'received a duplicate event'});
           }
-          return cb(null, datum);
+          return cb(err);
+        }
+        cb(null, datum);
+      };
+
+      if (datum.type == 'upload') {
+        const insertInTx = async (session) => {
+          // We need to insert a dataSet (datum's with type == "upload") into
+          // both the deviceData and deviceDataSets collection because as the
+          // migration from deviceData to deviceDataSets happens, some not
+          // yet updated clients might still expect dataSet to be in the old
+          // deviceData collection.
+          await mongoClient.collection('deviceData').insertOne(datum, {session});
+          await mongoClient.collection('deviceDataSets').insertOne(datum, {session});
+        };
+        mongoClient.transact(insertInTx, errHandler);
+      }
+      else {
+        mongoClient.withCollection(getCollectionName(datum), cb, function(coll, cb){
+          coll.insertOne(datum, errHandler);
         });
-      });
+      }
     },
     updateDatum: function(datum, cb) {
       pre.hasProperty(datum, 'id');
@@ -274,7 +271,24 @@ module.exports = function(mongoClient){
       pre.hasProperty(datum, '_groupId');
       datum.modifiedTime = new Date();
       var filteredDatum = filterDatumForMongo(datum);
-      updateDatumInternal(filteredDatum, 0, cb);
+
+      let firstResult = null;
+      const collections = getCollections(datum);
+      // In order to handle concurrent updates / avoid lost updates we will
+      // always run this in a transaction to mimick the behaviour of the
+      // previous updateDatumInternal code.
+      const updateInTx = async (session) => {
+        for (let collectionName of collections) {
+          const collection = mongoClient.collection(collectionName);
+          const result = await updateDatumInternal(session, collection, filteredDatum);
+          if (firstResult == null) {
+            firstResult = result;
+          }
+        }
+      };
+      mongoClient.transact(updateInTx, (err) => {
+        cb(err, firstResult);
+      });
     },
     addOrUpdateDatum: function(datum, cb) {
       if (datum.createdTime == null) {
@@ -285,20 +299,32 @@ module.exports = function(mongoClient){
     },
     storeData: function(data, cb) {
       data.modifiedTime = new Date();
-      mongoClient.withCollection('deviceData', cb, function(collection, cb){
-        collection.insertOne(data, {keepGoing: true}, cb);
-      });
+      if (data.type == 'upload') {
+        const insertInTx = async (session) => {
+          await mongoClient.collection('deviceData').insertOne(data, {session});
+          await mongoClient.collection('deviceDataSets').insertOne(data, {session});
+        };
+        mongoClient.transact(insertInTx, cb);
+      }
+      else {
+        mongoClient.withCollection(getCollectionName(data), cb, function(coll, cb){
+          coll.insertOne(data, cb);
+        });
+      }
     },
     deleteData: function(groupId, cb) {
-      mongoClient.withCollection('deviceData', cb, function(collection, cb){
-        collection.deleteOne({ groupId: groupId }, function(err){
-          if (err != null) {
-            cb(err);
-          } else {
-            collection.deleteOne({ _groupId: groupId }, cb);
-          }
-        });
-      });
+      const deleteInTx = async (session) => {
+        const dataSetColl = mongoClient.collection('deviceDataSets');
+        const dataColl = mongoClient.collection('deviceData');
+        // Not sure which of these delete results to return so just return
+        // the deviceData delete _groupId one as the previous code did.
+        await dataSetColl.deleteOne({ groupId: groupId }, {session});
+        await dataSetColl.deleteOne({ _groupId: groupId }, {session});
+        await dataColl.deleteOne({ groupId: groupId }, {session});
+        await dataColl.deleteOne({ _groupId: groupId }, {session});
+      };
+
+      mongoClient.transact(deleteInTx, cb);
     },
 
     setSummaryOutdated: function(userId, typ, cb) {

--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -169,19 +169,16 @@ module.exports = function(mongoClient){
     // I believe a datum is always meant to be type != 'upload' (?) but the ingestionApiTest.js file has
     // datums of type: 'upload' so we need to check both collections.
     getDatum: function(id, groupId, cb) {
-      async.map(['deviceDataSets', 'deviceData'], (collectionName, asyncCb) => {
-        mongoClient.withCollection(collectionName, asyncCb, function(coll, cb){
-          coll.findOne({_id: misc.generateId([id, groupId])}, function(err, result) {
-            cb(err, result);
-          });
-        });
-      }, (err, results) => {
-        if (err) {
-          return cb(err);
+      async function get() {
+        const query = {_id: misc.generateId([id, groupId])};
+        const obj = await mongoClient.collection('deviceDataSets').findOne(query);
+        if (obj) {
+          return obj;
         }
-        // Return the first non empty object otherwise just the first object.
-        cb(null, results.find(obj => !!obj) || results[0]);
-      });
+        return mongoClient.collection('deviceData').findOne(query);
+      };
+      const fn = util.callbackify(get);
+      fn(cb);
     },
     getDatumBefore: function(datum, cb) {
       // Due to migrations, a datum of type == "upload" may live in multiple

--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -119,7 +119,8 @@ module.exports = function(mongoClient){
     }
 
     const modificationOpts = {
-      writeConcern: {j: true},
+      readConcern: { level: 'majority' },
+      writeConcern: { w: 'majority', j: true },
       session: session,
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -720,7 +720,7 @@
     "cli": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
-      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "integrity": "sha512-41U72MB56TfUMGndAKK8vJ78eooOD4Z5NOL4xEfjc0c23s+6EYKXlXsmACBVclLP1yOfWCgEganVzddVrSNoTg==",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
@@ -728,17 +728,26 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.4",
+            "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -904,7 +913,7 @@
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "integrity": "sha512-duS7VP5pvfsNLDvL1O4VOEbw37AI3A4ZUQYemvDlnpGrNu9tprR7BYWpDYwC0Xia0Zxz5ZupdiIrUp0GH1aXfg==",
       "dev": true,
       "requires": {
         "date-now": "^0.1.4"
@@ -1007,7 +1016,7 @@
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "integrity": "sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw==",
       "dev": true
     },
     "debug": {
@@ -1158,15 +1167,15 @@
       },
       "dependencies": {
         "domelementtype": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
-          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+          "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
           "dev": true
         },
         "entities": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
           "dev": true
         }
       }
@@ -1180,7 +1189,7 @@
     "domhandler": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
       "dev": true,
       "requires": {
         "domelementtype": "1"
@@ -1189,7 +1198,7 @@
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
       "dev": true,
       "requires": {
         "dom-serializer": "0",
@@ -1264,7 +1273,7 @@
     "entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ==",
       "dev": true
     },
     "error-ex": {
@@ -1384,7 +1393,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true
     },
     "expand-brackets": {
@@ -2638,7 +2647,7 @@
     "htmlparser2": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
       "dev": true,
       "requires": {
         "domelementtype": "1",
@@ -2651,13 +2660,13 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2669,7 +2678,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
           "dev": true
         }
       }
@@ -3051,18 +3060,17 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jshint": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
-      "integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.6.tgz",
+      "integrity": "sha512-IVdB4G0NTTeQZrBoM8C5JFVLjV2KtZ9APgybDA1MK73xb09qFs0jCXyQLnCOp1cSZZZbvhq/6mfXHUTaDkffuQ==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
         "exit": "0.1.x",
         "htmlparser2": "3.8.x",
-        "lodash": "~4.17.19",
+        "lodash": "~4.17.21",
         "minimatch": "~3.0.2",
-        "shelljs": "0.3.x",
         "strip-json-comments": "1.0.x"
       }
     },
@@ -4861,12 +4869,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
-    "shelljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "integrity": "sha512-Ny0KN4dyT8ZSCE0frtcbAJGoM/HTArpyPkeli1/00aYfm0sbD/Gk/4x7N2DP9QKGpBsiQH7n6rpm1L79RtviEQ==",
-      "dev": true
-    },
     "sinon": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.12.2.tgz",
@@ -5220,7 +5222,7 @@
     "strip-json-comments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
       "dev": true
     },
     "sundial": {

--- a/test/api/ingestionApiTest.js
+++ b/test/api/ingestionApiTest.js
@@ -43,9 +43,18 @@ describe('ingestion API', function () {
   });
 
   beforeEach(function (done) {
-    mongoClient.withCollection('deviceData', done, function (coll, cb) {
-      coll.deleteMany({}, cb);
-    });
+    async.parallel([
+      (cb) => {
+        mongoClient.withCollection('deviceData', cb, function (coll, cb) {
+          coll.deleteMany({}, cb);
+        });
+      },
+      (cb) => {
+        mongoClient.withCollection('deviceDataSets', cb, function (coll, cb) {
+          coll.deleteMany({}, cb);
+        });
+      }
+    ], done);
   });
 
   beforeEach(function (done) {
@@ -74,7 +83,8 @@ describe('ingestion API', function () {
             return done(err);
           }
 
-          mongoClient.withCollection('deviceData', done, function(coll, cb){
+          const collectionName = input[0].type == 'upload' ? 'deviceDataSets' : 'deviceData';
+          mongoClient.withCollection(collectionName, done, function(coll, cb){
             coll.find().sort({"time": 1, "id": 1, "_version": 1}).toArray(function(err, results){
               expect(results.map(function(e){ return _.omit(e, 'createdTime', 'modifiedTime', "_id", '_archivedTime'); }))
                 .deep.equals(output.map(function(e){ e._userId = userId; e._groupId = groupId; return e; }));

--- a/test/streamDAOTest.js
+++ b/test/streamDAOTest.js
@@ -36,9 +36,18 @@ describe('streamDAO', function(){
   });
 
   beforeEach(function(done){
-    mongoClient.withCollection('deviceData', done, function(coll, cb) {
-      coll.deleteMany({}, cb);
-    });
+    async.parallel([
+      (cb) => {
+        mongoClient.withCollection('deviceData', cb, function (coll, cb) {
+          coll.deleteMany({}, cb);
+        });
+      },
+      (cb) => {
+        mongoClient.withCollection('deviceDataSets', cb, function (coll, cb) {
+          coll.deleteMany({}, cb);
+        });
+      }
+    ], done);
   });
 
   beforeEach(function(done){

--- a/test/streamDAOTest.js
+++ b/test/streamDAOTest.js
@@ -156,20 +156,24 @@ describe('streamDAO', function(){
           return done(err);
         }
 
-        if (count === 0) {
+        if (count < 2) {
           ++count;
           return;
         }
 
         mongoClient.withCollection('deviceData', done, function(coll, done){
           coll.find({f: 'a'}).toArray(function(err, elements){
-            expect(elements).to.have.length(3);
+            expect(elements).to.have.length(4);
             expect(elements.map(function(e){ return e._id; })).to.include.members(
               [expectedId, expectedId + '_0', expectedId + '_1']
             );
             expect(elements.filter(function(e){ return e._active; })).to.have.length(1);
+            // Since all updates are executing concurrently we don't know
+            // which will update "win" out so check that the property 'v' is
+            // in one of the updateed values.
+            expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('v').within(2828, 2830);
             expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('id').equals('abcd');
-            expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('_version').equals(2);
+            expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('_version').equals(3);
 
             done(err);
           });
@@ -179,6 +183,7 @@ describe('streamDAO', function(){
       var expectedId = misc.generateId(['abcd', 'g']);
       streamDAO.updateDatum({id: 'abcd', f: 'a', v: 2828, _userId: 'u', _groupId: 'g'}, theCallback);
       streamDAO.updateDatum({id: 'abcd', f: 'a', v: 2829, _userId: 'u', _groupId: 'g'}, theCallback);
+      streamDAO.updateDatum({id: 'abcd', f: 'a', v: 2830, _userId: 'u', _groupId: 'g'}, theCallback);
     });
   });
 

--- a/test/streamDAOTest.js
+++ b/test/streamDAOTest.js
@@ -164,13 +164,15 @@ describe('streamDAO', function(){
         mongoClient.withCollection('deviceData', done, function(coll, done){
           coll.find({f: 'a'}).toArray(function(err, elements){
             expect(elements).to.have.length(4);
-            expect(elements.map(function(e){ return e._id; })).to.include.members(
-              [expectedId, expectedId + '_0', expectedId + '_1']
+            // use to.have instead of to.include because we're expecting an
+            // exact number of elements.
+            expect(elements.map(function(e){ return e._id; })).to.have.members(
+              [expectedId, expectedId + '_0', expectedId + '_1', expectedId + '_2']
             );
             expect(elements.filter(function(e){ return e._active; })).to.have.length(1);
             // Since all updates are executing concurrently we don't know
-            // which will update "win" out so check that the property 'v' is
-            // in one of the updateed values.
+            // which update will "win" out so check that the property 'v' is
+            // in one of the updated values.
             expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('v').within(2828, 2830);
             expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('id').equals('abcd');
             expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('_version').equals(3);

--- a/test/streamDAOTest.js
+++ b/test/streamDAOTest.js
@@ -169,6 +169,7 @@ describe('streamDAO', function(){
             );
             expect(elements.filter(function(e){ return e._active; })).to.have.length(1);
             expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('id').equals('abcd');
+            expect(elements.filter(function(e){ return e._active; })[0]).to.have.property('_version').equals(2);
 
             done(err);
           });


### PR DESCRIPTION
Update code to handle data uploads in both new collection `deviceDataSets` and `deviceData`. Run modifications in a transaction.

Do all modifications of dataSets (datum.type == "upload") across old deviceData and new deviceDataSets collection in a transaction. Unfortunately the callback API is far too messy for this so some refactoring to use async/await was added.

`updateDatumInternal` was also refactored to be asynchronous and to get rid of the recursive-like setTimeOut that is no longer needed as the transactions API will already prevent concurrent updates and automatically retry for us.