### PR TITLE
[BACK-1758] Single read and write from appropriate collection for datum and uploads.

### DIFF
--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -164,9 +164,7 @@ module.exports = function(mongoClient){
       mongoClient.withCollection(getCollectionName(datum), cb, function(coll, tempCb){
         const find = util.callbackify(() => {
           return coll.find({
-            $or: [{time: {$lt: datum.time}},
-                  {time: {$lt: new Date(datum.time)}}
-                 ],
+            time: {$lt: new Date(datum.time)},
             _groupId: datum._groupId,
             _active: true,
             type: datum.type,

--- a/lib/streamDAO.js
+++ b/lib/streamDAO.js
@@ -145,27 +145,6 @@ module.exports = function(mongoClient){
     return datum;
   }
 
-  // collections that dataSets may live in. Due to migrations, some may still
-  // be in the deviceData collection. Eventually all of them will be migrated
-  // to the deviceDataSets collection but until then, we must check both
-  // collections when trying to retrieve a dataSet. Once migration is done
-  // this should just be the single collection ['deviceDataSets']
-  const deviceDataSetCollections = ['deviceDataSets', 'deviceData'];
-
-  // collection for deviceData. This is always just a single collection but is
-  // used as an array so that we can use the same parameterized function
-  // whether we're touching a dataSet or non-dataSet datum and will just pass
-  // the appropriate array of collections to the function.
-  const deviceDataCollections = ['deviceData'];
-
-  // returns all the collections a datum may reside in based on its type.
-  // only for datum.type == "upload" will it possibly be in more than one collection due
-  // to an ongoing migration. Once this migration is complete, you can return just ['deviceDataSets']
-  // for datum.type == "upload"
-  function getCollections(datum) {
-    return typeof datum?.type === 'string' && datum.type.toLowerCase() === 'upload' ? deviceDataSetCollections : deviceDataCollections;
-  }
-
   return {
     // I believe a datum is always meant to be type != 'upload' (?) but the ingestionApiTest.js file has
     // datums of type: 'upload' so we need to check both collections.
@@ -182,40 +161,29 @@ module.exports = function(mongoClient){
       fn(cb);
     },
     getDatumBefore: function(datum, cb) {
-      // Due to migrations, a datum of type == "upload" may live in multiple
-      // collections as it is being migrated over so we need to map over
-      // possible collections and return the one with a value.
-      async.map(getCollections(datum), (collectionName, asyncCb) => {
-        mongoClient.withCollection(collectionName, asyncCb, function(coll, cb){
-          const find = util.callbackify(() => {
-            return coll.find({
-              $or: [{time: {$lt: datum.time}},
-                    {time: {$lt: new Date(datum.time)}}
-                   ],
-              _groupId: datum._groupId,
-              _active: true,
-              type: datum.type,
-              deviceId: datum.deviceId,
-              source: datum.source
-            })
-            .sort({ "time": -1 })
-            .limit(1)
-            .toArray();
-          });
-
-          find((err, arr) => {
-            if (err == null && arr[0]) {
-              convertDatesToLegacy(arr[0]);
-            }
-            return cb(err, arr[0]);
-          });
+      mongoClient.withCollection(getCollectionName(datum), cb, function(coll, tempCb){
+        const find = util.callbackify(() => {
+          return coll.find({
+            $or: [{time: {$lt: datum.time}},
+                  {time: {$lt: new Date(datum.time)}}
+                 ],
+            _groupId: datum._groupId,
+            _active: true,
+            type: datum.type,
+            deviceId: datum.deviceId,
+            source: datum.source
+          })
+          .sort({ "time": -1 })
+          .limit(1)
+          .toArray();
         });
-      }, (err, results) => {
-        if (err) {
-          return cb(err);
-        }
-        // Return the first non empty object otherwise just the first object.
-        cb(null, results.find(obj => !!obj) || results[0]);
+
+        find((err, arr) => {
+          if (err == null && arr[0]) {
+            convertDatesToLegacy(arr[0]);
+          }
+          return tempCb(err, arr[0]);
+        });
       });
     },
     insertDatum: function(datum, cb) {
@@ -245,23 +213,9 @@ module.exports = function(mongoClient){
         cb(null, datum);
       };
 
-      if (datum.type == 'upload') {
-        const insertInTx = async (session) => {
-          // We need to insert a dataSet (datum's with type == "upload") into
-          // both the deviceData and deviceDataSets collection because as the
-          // migration from deviceData to deviceDataSets happens, some not
-          // yet updated clients might still expect dataSet to be in the old
-          // deviceData collection.
-          await mongoClient.collection('deviceData').insertOne(datum, {session});
-          await mongoClient.collection('deviceDataSets').insertOne(datum, {session});
-        };
-        mongoClient.transact(insertInTx, errHandler);
-      }
-      else {
-        mongoClient.withCollection(getCollectionName(datum), cb, function(coll, cb){
-          coll.insertOne(datum, errHandler);
-        });
-      }
+      mongoClient.withCollection(getCollectionName(datum), cb, function(coll, cb){
+        coll.insertOne(datum, errHandler);
+      });
     },
     updateDatum: function(datum, cb) {
       pre.hasProperty(datum, 'id');
@@ -271,18 +225,12 @@ module.exports = function(mongoClient){
       var filteredDatum = filterDatumForMongo(datum);
 
       let firstResult = null;
-      const collections = getCollections(datum);
       // In order to handle concurrent updates / avoid lost updates we will
       // always run this in a transaction to mimick the behaviour of the
       // previous updateDatumInternal code.
       const updateInTx = async (session) => {
-        for (let collectionName of collections) {
-          const collection = mongoClient.collection(collectionName);
-          const result = await updateDatumInternal(session, collection, filteredDatum);
-          if (firstResult == null) {
-            firstResult = result;
-          }
-        }
+        const collection = mongoClient.collection(getCollectionName(datum));
+        firstResult = await updateDatumInternal(session, collection, filteredDatum);
       };
       mongoClient.transact(updateInTx, (err) => {
         cb(err, firstResult);
@@ -297,18 +245,9 @@ module.exports = function(mongoClient){
     },
     storeData: function(data, cb) {
       data.modifiedTime = new Date();
-      if (data.type == 'upload') {
-        const insertInTx = async (session) => {
-          await mongoClient.collection('deviceData').insertOne(data, {session});
-          await mongoClient.collection('deviceDataSets').insertOne(data, {session});
-        };
-        mongoClient.transact(insertInTx, cb);
-      }
-      else {
-        mongoClient.withCollection(getCollectionName(data), cb, function(coll, cb){
+      mongoClient.withCollection(getCollectionName(data), cb, function(coll, cb){
           coll.insertOne(data, cb);
         });
-      }
     },
     deleteData: function(groupId, cb) {
       const deleteInTx = async (session) => {


### PR DESCRIPTION
This is meant to be merged **AFTER** dual read/writes for tide-whisperer, platform-data and jellyfish have been deployed and then the migrator of uploads to the `deviceDataSets` collection is ran to completion.

This removes the dual read/write of data and does a single read and write from the appropriate data collection.
Reads and writes to `deviceData` collection for a datum and `deviceDataSets` for a dataSet/upload.